### PR TITLE
added support for waveshare rev2.1

### DIFF
--- a/flows/main.json
+++ b/flows/main.json
@@ -10629,6 +10629,11 @@
             },
             {
                 "label": "",
+                "value": "waveshareRev2.1",
+                "type": "str"
+            },
+            {
+                "label": "",
                 "value": "pscope_hat",
                 "type": "str"
             }


### PR DESCRIPTION
Motors attached to the new waveshare hats does not work with the current hardware settings. According to [Waveshare Wiki](https://www.waveshare.com/wiki/Stepper_Motor_HAT)'s official site,
> New version (the purchase date is later than 2021.01.05, the PCB board is printed with the word Rev2.1)

The difference between waveshare and waveshareRev2.1 is
> The difference is that the new version uses high-level enable, so the motor will not work when the Raspberry Pi doesn't initialize the enable GPIO and let it output high-level

Below is a screenshot of their demo codes for DRV8825.py. Left side is the old code and right side is the new Rev2.1.
![wavesharerev2_screenshot](https://user-images.githubusercontent.com/32024479/147505768-6dbf2994-6eaf-409b-b1a0-82cbe303cb04.png)
