### PR TITLE
Try to deploy docs from master branch directly to GitHub Pages

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -43,7 +43,7 @@ jobs:
         run: poetry -C ./documentation/ run poe --root ./documentation/ check
 
       - name: Build documentation
-        run: poetry -C ./documentation/ run poe --root ./documentation/ check
+        run: poetry -C ./documentation/ run poe --root ./documentation/ build
 
       - name: Upload website archive
         uses: actions/upload-artifact@v3

--- a/.github/workflows/documentation-deploy-edge.yml
+++ b/.github/workflows/documentation-deploy-edge.yml
@@ -9,14 +9,33 @@ on:
     paths:
       - 'documentation/**'
       - '.github/workflows/documentation-deploy-edge.yml'
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest
+# queued. But do not cancel in-progress runs - we want these deploymeents to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  deployment:
+  build:
     runs-on: ubuntu-latest
-    environment: documentation-edge
-
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Pages
+        id: pages
+        uses: actions/configure-pages@v3
 
       - name: Install poetry
         run: pipx install poetry==1.5.0
@@ -33,5 +52,21 @@ jobs:
         run: |
           poetry -C ./documentation/ install --with docs
 
-      - name: Deploy documentation
-        run: poetry -C ./documentation/ run poe --root ./documentation/ deploy-gh
+      - name: Build documentation
+        run: poetry -C ./documentation/ run poe --root ./documentation/ build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./documentation/site
+
+  deploy:
+    environment:
+      name: documentation-edge
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -42,7 +42,7 @@ cd /some/path/here/PlanktoScope/documentation
 poetry run poe preview
 ```
 
-Then you can open the documentation website in your web browser at http://localhost:8000/PlanktoScope/ . Whenever you change a documentation source file, save your changes, and return to the web browser tab with the locally hosted documentation site, your changes will automatically appear within a few seconds!
+Then you can open the documentation website in your web browser at http://localhost:8000/ . Whenever you change a documentation source file, save your changes, and return to the web browser tab with the locally hosted documentation site, your changes will automatically appear within a few seconds!
 
 #### Checking for errors
 

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -2,7 +2,6 @@
 site_name: PlanktoScope
 site_description: An open and affordable imaging platform for \
   citizen oceanography
-site_url: https://planktoscope.github.io/PlanktoScope/
 repo_name: PlanktoScope
 repo_url: https://github.com/PlanktoScope/PlanktoScope
 

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -64,4 +64,3 @@ build = "mkdocs build --clean --strict"
 build-check = "mkdocs build --clean --strict --no-directory-urls"
 check-links = "linkchecker --config .linkcheckerrc site"
 check = ["build-check", "check-links"]
-deploy-gh = "mkdocs gh-deploy --force"


### PR DESCRIPTION
This PR attempts to address part of #144 and improve upon #148 by modifying the GitHub Actions workflow for deploying the latest development version of the PlanktoScope documentation (on the master branch) to GitHub Pages. Hopefully, this PR will remove the need for us to have a separate `gh-pages` branch with two separate GitHub Actions deployments involved in getting the website onto GitHub Pages - instead, the `documentation-deploy-edge.yml` workflow will hopefully upload the built website directly to GitHub Pages.