### PR TITLE
Fix incorrect container image name

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -50,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/planktoscope/forklift
+          images: ghcr.io/planktoscope/project-docs
           tags: |
             type=match,pattern=documentation/v(.*)
             type=edge,branch=master

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # Build documentation website
       - name: Install poetry
         run: pipx install poetry==1.5.0
 
@@ -46,6 +47,7 @@ jobs:
       - name: Build documentation
         run: poetry -C ./documentation/ run poe --root ./documentation/ build
 
+      # Build and publish Docker container image
       - name: Get Docker metadata
         id: meta
         uses: docker/metadata-action@v4
@@ -82,6 +84,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      # Upload documentation website as archive
       - name: Upload website archive
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This PR fixes an error introduced in #155 which prevented the Docker container image (for serving the documentation website via Caddy, for deployment on PlanktoScopes) from being uploaded to the GitHub container registry, because an incorrect container image name was used.