### PR TITLE
Simplify the Docker image tag used for pushed Git tags

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           images: ghcr.io/planktoscope/project-docs
           tags: |
-            type=match,pattern=documentation/v(.*)
+            type=match,pattern=documentation/v(.*),group=1
             type=edge,branch=master
             type=ref,event=branch,enable=${{ github.ref != format('refs/heads/{0}', 'master') && github.ref != format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}


### PR DESCRIPTION
Previously, a Git tag like [`documentation/v2023.9.0-alpha.0`](https://github.com/PlanktoScope/PlanktoScope/releases/tag/documentation%2Fv2023.9.0-alpha.0) would cause a Docker image to be tagged as [`documentation-v2023.9.0-alpha.0`](https://github.com/PlanktoScope/PlanktoScope/pkgs/container/project-docs/120956077?tag=documentation-v2023.9.0-alpha.0). This hotfix attempts to change the Docker image tag to something like `2023.9.0-alpha.0`.