### PR TITLE
Update setup scripts and bump version numbers for v2023.9.0-beta.1

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -9,6 +9,8 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+## v2023.9.0-beta.1 - 2023-09-14
+
 ### Added
 
 - (System: networking) The PlanktoScope can now also be accessed using the domain name `pkscope.local` from any web browser where `planktoscope.local` previously worked. We recommend using http://pkscope.local instead of http://planktoscope.local to access your PlanktoScope, for consistency with other domain name formats (see the "Changes" section for details).
@@ -40,7 +42,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - (System: networking) The PlanktoScope no longer generates any machine names or SSIDs which are so long that they prevent the wifi hotspot network from being brought up.
 - (Application: backend) The segmenter no longer crashes and fails to respond immediately after attempting to start segmentation.
 - (Application: preset settings, GUI) The default setting for the pscopehat version of the Node-RED dashboard is now the 300 um capillary, since that version of the hardware is meant to be used with 300 um capillaries. Previously, the default was the 200 um ibidi slide.
-- (Application: preset settings) All default settings for all hardware versions now include a default pixel sizecalibration of 0.75 um/pixel. Previously, the default settings for v2.1 and v2.3 were missing this setting, which would cause the segmenter to crash when processing datasets generated on PlanktoScopes using the v2.1 or v2.3 hardware settings.
+- (Application: preset settings) All default settings for all hardware versions now include a default pixel size calibration of 0.75 um/pixel. Previously, the default settings for v2.1 and v2.3 were missing this setting, which would cause the segmenter to crash when processing datasets generated on PlanktoScopes using the v2.1 or v2.3 hardware settings.
 - (Application: preset settings, GUI) The Node-RED dashboard now correctly lists the selected hardware version in the "Hardware Settings" page's "Hardware Version" dropdown menu upon startup.
 - (Application: GUI) The Node-RED dashboard now (hopefully) is able to determine the camera type from the Python backend.
 

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -5,7 +5,7 @@
 
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 forklift_version="0.3.1"
-pallet_version="7e2a3bb95a91717068b2f432cbfd81a49788760b"
+pallet_version="v2023.9.0-beta.1"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C /home/pi/.local/bin -xz forklift

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -31,8 +31,8 @@ python3 -m pip install --user pipx==1.2.0
 python3 -m pipx ensurepath
 
 # Download device-backend monorepo
-backend_version="100f19612489d5c546518fb1e1e5e20f834070f7" # this should be either a version tag, branch name, or commit hash
-backend_version_type="hash" # this should be either "version-tag", "branch", or "hash"
+backend_version="v2023.9.0-beta.1" # this should be either a version tag, branch name, or commit hash
+backend_version_type="version-tag" # this should be either "version-tag", "branch", or "hash"
 case "$backend_version_type" in
   "version-tag")
     wget "https://github.com/PlanktoScope/device-backend/archive/refs/tags/$backend_version.zip"

--- a/software/node-red-dashboard/flows/adafruithat.json
+++ b/software/node-red-dashboard/flows/adafruithat.json
@@ -9347,7 +9347,7 @@
         "once": true,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "v2023.9.0-beta.0",
+        "payload": "v2023.9.0-beta.1",
         "payloadType": "str",
         "x": 120,
         "y": 520,

--- a/software/node-red-dashboard/flows/pscopehat.json
+++ b/software/node-red-dashboard/flows/pscopehat.json
@@ -9292,7 +9292,7 @@
         "once": true,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "v2023.9.0-beta.0",
+        "payload": "v2023.9.0-beta.1",
         "payloadType": "str",
         "x": 100,
         "y": 520,

--- a/software/node-red-dashboard/package.json
+++ b/software/node-red-dashboard/package.json
@@ -1,7 +1,7 @@
 {
     "name": "planktoscope",
     "description": "PlanktoScope main software project",
-    "version": "2023.9.0-beta.0",
+    "version": "2023.9.0-beta.1",
     "dependencies": {
         "node-red-contrib-dir2files": "^0.3.0",
         "node-red-contrib-gpsd": "^1.0.4",


### PR DESCRIPTION
This PR updates the distro setup scripts and the software `CHANGELOG.md` for the v2023.9.0-beta.1 prerelease.

To test this PR, run the following commands on an RPi with a fresh 2023-06-03-raspios-bullseye-armhf-lite.img.xz SD card image:
```
cd /home/pi
wget https://github.com/PlanktoScope/PlanktoScope/archive/refs/heads/feature/bump-version.zip
unzip bump-version.zip; rm bump-version.zip
mv PlanktoScope-feature-bump-version PlanktoScope
/home/pi/PlanktoScope/software/distro/setup/setup.sh adafruithat
sudo shutdown now
```
Note: to set up the SD card image with support for the PlanktoScope HAT instead of the Adafruit HAT, replace the above `adafruithat` with `pscopehat`.