### PR TITLE
Apply the forklift pallet as part of the SD card setup process

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -9,9 +9,14 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Changed
+
+- (System: infrastructure) Forklift has been upgraded from v0.3.1 to v0.4.0, which includes breaking changes to the schema of Forklift repositories and pallets.
+
 ### Fixed
 
 - (Application: GUI) The white balance gains are now only validated and sent to the backend _after_ the user changes focus away from the input field, instead of being validated and sent 300 ms after the user pauses while editing the value in the input field. This prevents the input validation from being run while the user is still editing the value.
+- (System: infrastructure) The SD card setup scripts now apply the Forklift pallet in order to create the Docker Compose services and resources ahead-of-time (rather than waiting for the first boot to do that work), so that the first boot of the SD card image will be much faster.
 
 ## v2023.9.0-beta.1 - 2023-09-14
 

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -26,7 +26,7 @@ echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y # get the list of packages from the docker repo
-VERSION_STRING=5:24.0.5-1~raspbian.11~bullseye
+VERSION_STRING=5:24.0.5-1~raspbian.11~bullseye # FIXME: make this work on both bullseye and bookworm
 # The following command will fail with a post-install error if the system installed kernel updates
 # via apt upgrade but was not rebooted before installing docker-ce; however, even if this error
 # is reported, docker will work after reboot.

--- a/software/distro/setup/planktoscope-app-env/cleanup/clean.sh
+++ b/software/distro/setup/planktoscope-app-env/cleanup/clean.sh
@@ -26,3 +26,7 @@ rm -f /home/pi/.python_history
 
 # Delete images from the documentation directory, since they're huge and we aren't using them anyways
 rm -rf /home/pi/PlanktoScope/documentation/
+
+# Delete auto-generated keys & certs from forklift apps, for security reasons
+rm -rf /var/lib/docker/volumes/apps_*/_data/*
+rm -rf /var/lib/docker/volumes/infra_*/_data/*

--- a/software/distro/setup/planktoscope-app-env/cleanup/clean.sh
+++ b/software/distro/setup/planktoscope-app-env/cleanup/clean.sh
@@ -28,5 +28,5 @@ rm -f /home/pi/.python_history
 rm -rf /home/pi/PlanktoScope/documentation/
 
 # Delete auto-generated keys & certs from forklift apps, for security reasons
-rm -rf /var/lib/docker/volumes/apps_*/_data/*
-rm -rf /var/lib/docker/volumes/infra_*/_data/*
+sudo rm -rf /var/lib/docker/volumes/apps_*/_data/*
+sudo rm -rf /var/lib/docker/volumes/infra_*/_data/*

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -5,7 +5,7 @@
 
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 forklift_version="0.4.0"
-pallet_version="afdb2c"
+pallet_version="fb6b9d"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C /home/pi/.local/bin -xz forklift

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -5,7 +5,7 @@
 
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 forklift_version="0.4.0"
-pallet_version="4fd9a86"
+pallet_version="afdb2c"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C /home/pi/.local/bin -xz forklift

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -11,7 +11,12 @@ curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_v
   | tar -C /home/pi/.local/bin -xz forklift
 /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
 /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt cache-repo
-sudo -E /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt cache-img
+# Note: cache-img downloads images even for disabled package deployments. We skip it to save disk
+# space (because the node-red container image used by a test package is >100 MB, even though we
+# don't need it yet), we don't yet have any packages in the pallet which someone might want to
+# enable, and because we're running plt apply anyways - that command will download images as needed
+# for each (enabled) package deployment.
+# sudo -E /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt cache-img
 sudo -E /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt apply
 # Note: we apply the pallet immediately so that the first boot of the image won't be excessively
 # slow (due to Docker Compose needing to create all the services from scratch rather than simply

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -12,8 +12,10 @@ curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_v
 /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
 /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt cache-repo
 sudo -E /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt cache-img
-# Note: we don't apply the pallet immediately because the Docker service won't work properly until a
-# reboot. Forklift apply doesn't actually cause the containers to exist after a reboot.
+sudo -E /home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt apply
+# Note: we apply the pallet immediately so that the first boot of the image won't be excessively
+# slow (due to Docker Compose needing to create all the services from scratch rather than simply
+# starting them).
 
 # Apply pallet after Docker is initialized, because the system needs to be restarted after Docker is
 # installed before the Docker service will be able to start successfully.

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -4,8 +4,8 @@
 # distribution
 
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
-forklift_version="0.3.1"
-pallet_version="v2023.9.0-beta.1"
+forklift_version="0.4.0"
+pallet_version="4fd9a86"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C /home/pi/.local/bin -xz forklift

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -26,7 +26,7 @@ $POETRY_VENV/bin/pip install cryptography==41.0.5
 $POETRY_VENV/bin/pip install poetry==1.6.1
 # Workaround for https://github.com/python-poetry/poetry/issues/3219, from
 # https://github.com/python-poetry/poetry/issues/3219#issuecomment-1540969935
-$POETRY_VENV/bin/poetry config installer.max-workers 2
+$POETRY_VENV/bin/poetry config installer.parallel false
 
 # Install pipx (not required, but useful)
 python3 -m pip install --user pipx==1.2.0

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -22,7 +22,7 @@ sudo apt-get install -y git python3-pip python3-venv
 POETRY_VENV=/home/pi/.local/share/pypoetry/venv
 mkdir -p $POETRY_VENV
 python3 -m venv $POETRY_VENV
-$POETRY_VENV/bin/pip install --upgrade pip==23.2.1 setuptools==68.1.2
+$POETRY_VENV/bin/pip install --upgrade pip==23.3.1 setuptools==68.1.2
 $POETRY_VENV/bin/pip install cryptography==39.0.1
 $POETRY_VENV/bin/pip install poetry==1.4.2
 
@@ -31,8 +31,8 @@ python3 -m pip install --user pipx==1.2.0
 python3 -m pipx ensurepath
 
 # Download device-backend monorepo
-backend_version="v2023.9.0-beta.1" # this should be either a version tag, branch name, or commit hash
-backend_version_type="version-tag" # this should be either "version-tag", "branch", or "hash"
+backend_version="31ae16dc7a39acf44302cf37ccabb48e4cf5b044" # this should be either a version tag, branch name, or commit hash
+backend_version_type="hash" # this should be either "version-tag", "branch", or "hash"
 case "$backend_version_type" in
   "version-tag")
     wget "https://github.com/PlanktoScope/device-backend/archive/refs/tags/$backend_version.zip"

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -22,9 +22,9 @@ sudo apt-get install -y git python3-pip python3-venv
 POETRY_VENV=/home/pi/.local/share/pypoetry/venv
 mkdir -p $POETRY_VENV
 python3 -m venv $POETRY_VENV
-$POETRY_VENV/bin/pip install --upgrade pip==23.3.1 setuptools==68.1.2
-$POETRY_VENV/bin/pip install cryptography==39.0.1
-$POETRY_VENV/bin/pip install poetry==1.4.2
+$POETRY_VENV/bin/pip install --upgrade pip==23.3.1 setuptools==68.2.2
+$POETRY_VENV/bin/pip install cryptography==40.0.5
+$POETRY_VENV/bin/pip install poetry==1.6.1
 
 # Install pipx (not required, but useful)
 python3 -m pip install --user pipx==1.2.0

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -23,7 +23,7 @@ POETRY_VENV=/home/pi/.local/share/pypoetry/venv
 mkdir -p $POETRY_VENV
 python3 -m venv $POETRY_VENV
 $POETRY_VENV/bin/pip install --upgrade pip==23.3.1 setuptools==68.2.2
-$POETRY_VENV/bin/pip install cryptography==40.0.5
+$POETRY_VENV/bin/pip install cryptography==41.0.5
 $POETRY_VENV/bin/pip install poetry==1.6.1
 
 # Install pipx (not required, but useful)

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -13,12 +13,11 @@ sudo apt-get update -y
 sudo apt-get install -y git python3-pip python3-venv
 
 # Install Poetry
-# Note: poetry 1.5.0 and above requires cryptography==40.0.2, which isn't available on piwheels and
-# can't build properly on the Raspberry Pi OS's bullseye 2023-05-03 release. Poetry 1.4.2 only
-# requires cryptography==39.0.1, according to its poetry.lock file
-# (see https://github.com/python-poetry/poetry/blob/1.4.2/poetry.lock). Because the poetry
-# installation process (whether with pipx or the official installer) always selects the most recent
-# version of the cryptography dependency, we must instead do a manual poetry installation.
+# Note: Because the poetry installation process (whether with pipx or the official installer) always
+# selects the most recent version of the cryptography dependency, we must instead do a manual poetry
+# installation to ensure that a wheel is available from piwheels for the cryptography dependency.
+# We have had problems in the past with a version of that dependency not being available from
+# piwheels.
 POETRY_VENV=/home/pi/.local/share/pypoetry/venv
 mkdir -p $POETRY_VENV
 python3 -m venv $POETRY_VENV

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -24,6 +24,9 @@ python3 -m venv $POETRY_VENV
 $POETRY_VENV/bin/pip install --upgrade pip==23.3.1 setuptools==68.2.2
 $POETRY_VENV/bin/pip install cryptography==41.0.5
 $POETRY_VENV/bin/pip install poetry==1.6.1
+# Workaround for https://github.com/python-poetry/poetry/issues/3219, from
+# https://github.com/python-poetry/poetry/issues/3219#issuecomment-1540969935
+$POETRY_VENV/bin/poetry config installer.max-workers 2
 
 # Install pipx (not required, but useful)
 python3 -m pip install --user pipx==1.2.0


### PR DESCRIPTION
This PR applies the Forklift pallet as part of the SD card setup process, in order to speed up the first boot of the PlanktoScope SD card image. This is because the first time the Forklift pallet is applied, Docker Compose must create volumes and containers from container images in a process that currently takes a long time - making the first boot really slow. This PR also upgrades some Python dependencies, partly to try to reduce the rate of errors occurring in either pip or poetry while downloading Python dependencies.

To test this PR, run the following commands on an RPi with a fresh 2023-06-03-raspios-bullseye-armhf-lite.img.xz SD card image:
```
cd /home/pi
wget https://github.com/PlanktoScope/PlanktoScope/archive/refs/heads/hotfix/setup-forklift-apply.zip
unzip setup-forklift-apply.zip; rm setup-forklift-apply.zip
mv PlanktoScope-hotfix-setup-forklift-apply PlanktoScope
/home/pi/PlanktoScope/software/distro/setup/setup.sh adafruithat
sudo shutdown now
```
Note: to set up the SD card image with support for the PlanktoScope HAT instead of the Adafruit HAT, replace the above `adafruithat` with `pscopehat`.