### PR TITLE
Add hardware v2.6 support

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -9,6 +9,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Added
+
+- (Application) A hardware configuration file for PlanktoScope hardware v2.6, which was previously missing, has been added.
+
 ### Changed
 
 - (System: infrastructure) Forklift has been upgraded from v0.3.1 to v0.4.0, which includes breaking changes to the schema of Forklift repositories and pallets.

--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -11,7 +11,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ### Added
 
-- (Application) A hardware configuration file for PlanktoScope hardware v2.6, which was previously missing, has been added.
+- (Application) A hardware configuration file for PlanktoScope hardware v2.6, which was previously missing, has been added. It is now the default hardware configuration file for `pscopehat` builds of the PlanktoScope distro.
 
 ### Changed
 

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -33,7 +33,7 @@ python3 -m pip install --user pipx==1.2.0
 python3 -m pipx ensurepath
 
 # Download device-backend monorepo
-backend_version="31ae16dc7a39acf44302cf37ccabb48e4cf5b044" # this should be either a version tag, branch name, or commit hash
+backend_version="0c43679de9c8709f66b554c62cc6094c865a4d37" # this should be either a version tag, branch name, or commit hash
 backend_version_type="hash" # this should be either "version-tag", "branch", or "hash"
 case "$backend_version_type" in
   "version-tag")

--- a/software/node-red-dashboard/flows/adafruithat.json
+++ b/software/node-red-dashboard/flows/adafruithat.json
@@ -10438,6 +10438,11 @@
                 "label": "",
                 "value": "PlanktoScope v2.5",
                 "type": "str"
+            },
+            {
+                "label": "",
+                "value": "PlanktoScope v2.6",
+                "type": "str"
             }
         ],
         "payload": "",

--- a/software/node-red-dashboard/flows/pscopehat.json
+++ b/software/node-red-dashboard/flows/pscopehat.json
@@ -10378,6 +10378,11 @@
                 "label": "",
                 "value": "PlanktoScope v2.5",
                 "type": "str"
+            },
+            {
+                "label": "",
+                "value": "PlanktoScope v2.6",
+                "type": "str"
             }
         ],
         "payload": "",


### PR DESCRIPTION
This PR fixes #264 by adding a v2.6 hardware configuration file. It is now the default hardware config on `pscopehat` builds of the PlanktoScope distro.