### PR TITLE
Add explanatory comment about image width/height in `raspimjpeg.conf`

### DIFF
--- a/scripts/raspimjpeg/raspimjpeg.conf
+++ b/scripts/raspimjpeg/raspimjpeg.conf
@@ -84,11 +84,20 @@ video_split 0
 MP4Box background
 MP4Box_fps 25
 MP4Box_cmd (set -e;MP4Box -fps %i -add %s %s > /dev/null 2>&1;rm "%s";) &
+
 #
 # Image Options
 #
-image_width 3280
-image_height 2464
+
+# Note: this file's image_width and image_height settings are actually ignored because different
+# PlanktoScope hardware versions have different image sensors with different widths and heights.
+# PlanktoScope hardware v2.1 produces images with width 3280 and height 2464, while PlanktoScope
+# hardware v2.5 & v2.6 produce images with width 4056 and height 3040. In reality, the PlanktoScope
+# software's python backend automatically detects the image sensor used and thus the correct values
+# of the image_width and image_height settings, and then directly tells raspimjpeg those values, so
+# that changing the values below should have no effect.
+image_width 4056
+image_height 3040
 image_quality 80
 
 #time lapse interval 0.1 sec units


### PR DESCRIPTION
This PR closes #258 by explaining that the `image_width` and `image_height` settings in the `raspimjpeg.conf` file are incorrect, ignored, and overridden by the Python backend.