### PR TITLE
Add a placeholder title for the proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,7 +1,7 @@
 ---
 name: Proposal
 about: A significant change to the project's software, hardware, processes, etc.
-title: ''
+title: 'proposal: [A short title for the proposal]'
 labels: proposal
 assignees: ''
 


### PR DESCRIPTION
This PR attempts to set a default placeholder title for the GitHub Issues template for making a new proposal.