### PR TITLE
Build a minimal version of the docs site, without hardware setup guides

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -93,3 +93,82 @@ jobs:
         with:
           name: documentation-website
           path: documentation/site
+
+  build-minimal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Build minimal documentation website (without hardware setup guides, to save space)
+      - name: Install poetry
+        run: pipx install poetry==1.5.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'poetry'
+          cache-dependency-path: |
+            documentation/poetry.lock
+
+      - name: Install build dependencies
+        run: |
+          poetry -C ./documentation/ install --with docs
+
+      - name: Import external assets
+        run: poetry -C ./documentation/ run poe --root ./documentation/ import-external-assets
+
+      - name: Make documentation minimal
+        run: poetry -C ./documentation/ run poe --root ./documentation/ make-minimal
+
+      - name: Check documentation
+        run: poetry -C ./documentation/ run poe --root ./documentation/ check
+
+      - name: Build documentation
+        run: poetry -C ./documentation/ run poe --root ./documentation/ build
+
+      # Build and publish Docker container image
+      - name: Get Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/planktoscope/project-docs
+          flavor: |
+            prefix=minimal-
+          tags: |
+            type=match,pattern=documentation/v(.*),group=1
+            type=edge,branch=master
+            type=ref,event=branch,enable=${{ github.ref != format('refs/heads/{0}', 'master') && github.ref != format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: github.event_name == 'push' || github.event_name == 'push tag'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./documentation
+          pull: true
+          push: ${{ github.event_name == 'push' || github.event_name == 'push tag' }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Upload documentation website as archive
+      - name: Upload website archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation-website-minimal
+          path: documentation/site

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -58,6 +58,7 @@ jobs:
           images: ghcr.io/planktoscope/project-docs
           tags: |
             type=match,pattern=documentation/v(.*),group=1
+            type=ref,event=pr
             type=edge,branch=master
             type=ref,event=branch,enable=${{ github.ref != format('refs/heads/{0}', 'master') && github.ref != format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
-        if: github.event_name == 'push' || github.event_name == 'push tag'
+        if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'push tag'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
-        if: github.event_name == 'push' || github.event_name == 'push tag'
+        if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'push tag'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -58,9 +58,9 @@ jobs:
           images: ghcr.io/planktoscope/project-docs
           tags: |
             type=match,pattern=documentation/v(.*),group=1
-            type=ref,event=pr
             type=edge,branch=master
             type=ref,event=branch,enable=${{ github.ref != format('refs/heads/{0}', 'master') && github.ref != format('refs/heads/{0}', 'main') }}
+            type=ref,event=pr
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
             type=sha
 
@@ -83,7 +83,7 @@ jobs:
         with:
           context: ./documentation
           pull: true
-          push: ${{ github.event_name == 'push' || github.event_name == 'push tag' }}
+          push: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'push tag' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -135,11 +135,12 @@ jobs:
         with:
           images: ghcr.io/planktoscope/project-docs
           flavor: |
-            prefix=minimal-
+            suffix=-minimal
           tags: |
             type=match,pattern=documentation/v(.*),group=1
             type=edge,branch=master
             type=ref,event=branch,enable=${{ github.ref != format('refs/heads/{0}', 'master') && github.ref != format('refs/heads/{0}', 'main') }}
+            type=ref,event=pr
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
             type=sha
 

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           context: ./documentation
           pull: true
-          push: ${{ github.event_name == 'push' || github.event_name == 'push tag' }}
+          push: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'push tag' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/documentation/docs/community/trainings.md
+++ b/documentation/docs/community/trainings.md
@@ -18,7 +18,7 @@ Organizing a build workshop can be a challenging but rewarding experience. It re
 
 Choosing the right production site for preparing and manufacturing the PlanktoScope Kits is an important step in the workshop planning process. The production site should have the necessary tools and equipment, as well as the knowledge and expertise to manufacture the PlanktoScope Kits. Here are a few things to consider when choosing a production site:
 
-1. **Check the Manufacturing and Assembly Guides**: Before choosing a production site, make sure to review the PlanktoScope [Kit Manufacturing Guide](../setup/hardware/v2.5/kit/index.md) and the [Device Assembly Guide](../setup/hardware/v2.5/assembly/index.md). These guides will provide detailed information on the necessary tools and equipment required for the production of the PlanktoScope Kits.
+1. **Check the Manufacturing and Assembly Guides**: Before choosing a production site, make sure to review the PlanktoScope Kit Manufacturing Guide and the Device Assembly Guide. These guides will provide detailed information on the necessary tools and equipment required for the production of the PlanktoScope Kits.
 1. **Visit [Fablab](https://fablabs.io/labs) and [Hackspaces](https://wiki.hackerspaces.org/List_of_Hacker_Spaces)**: Consider visiting Fablabs or Hackspaces in your region. These organizations often have a culture of openness and may be willing to support you with your project. They may have the necessary tools and equipment to produce the PlanktoScope Kits, as well as the knowledge and expertise to guide you through the production process.
 1. **Commercial Manufacturing**: Look for a facility that has the capability to handle small scale production runs, a good quality control process and a logistic plan to ship the product to the final destination. Many
 
@@ -58,12 +58,12 @@ By following this process, you can ensure that all materials are procured and or
 
 Kit preparation for the workshop is an important step in the preparation process. This ensures that participants have the materials and equipment they need to complete the workshop and build their own PlanktoScope. Here are a few things to keep in mind when preparing the kits:
 
-1. **Review the Bill of Materials (BOM)**: Review the Bill of Materials (BOM) for the PlanktoScope to ensure that you have all the necessary parts and materials for the workshop. The parts list can be found in the [Device Assembly Guide](../setup/hardware/v2.5/assembly/index.md) and lists all components and quantities needed to build a microscope.
+1. **Review the Bill of Materials (BOM)**: Review the Bill of Materials (BOM) for the PlanktoScope to ensure that you have all the necessary parts and materials for the workshop. The parts list can be found in the Device Assembly Guide and lists all components and quantities needed to build a microscope.
 2. **Divide the kit components according to the BOM**: Once the materials have been received, divide the kit components from the orders according to the Bill of Materials (BOM) of the PlanktoScope. This will ensure that each participant receives the correct components and that there are no missing parts.
 3. **Have extra components**: Have extra components on hand in case of any missing or damaged parts during the workshop.
 4. **Package the kits**: Package the kits in a way that makes it easy for the participants to find and use the components during the workshop.
-5. **Label materials**: Label the packages as described in [Device Assembly Guide](../setup/hardware/v2.5/assembly/index.md) so that they are easy to find and distribute during the workshop.
-6. **Preparation of the housing parts**: Prepare the housing parts by applying the surface sealant and insert the nuts to screw the housing as described in the [Kit Manufacturing Guide](../setup/hardware/v2.5/kit/index.md#finishing).
+5. **Label materials**: Label the packages as described in Device Assembly Guide so that they are easy to find and distribute during the workshop.
+6. **Preparation of the housing parts**: Prepare the housing parts by applying the surface sealant and insert the nuts to screw the housing as described in the Kit Manufacturing Guide.
 7. **Cutting and soldering of electronic cables**: Cut and solder the electronic cables for the PlanktoScope. This will save time during the workshop and ensure that the participants have all the necessary cables to complete the assembly.
 8. **Setting up the embedded development environment**: Set up the embedded development environment and flash the eeprom of the PlanktoScope hat. This will ensure that the PlanktoScope hat is ready to be used during the workshop.
 9. **Download the Raspberry Pi image**: Download the Raspberry Pi image and flash it to the SD card. This will ensure that the participants have a ready to use image for the PlanktoScope.
@@ -85,7 +85,7 @@ It's finally here! After all the planning, preparation, and anticipation, the bu
 6. **Introduction round**: Begin with a round of introductions and give everyone a chance to introduce themselves, their background, and their interest in the project.
 7. **Provide an overview**: Provide details about the project, including the general mode of operation, the working materials such as the kit, the documentation and the git repository.
 8. **Provide the Kits and Tools**: Provide the Kit and Tools to each participant with a kit and the necessary tools.
-9. **Follow the build instructions**: Depending on the format you have chosen, start implementing by following the [Kit Manufacturing guide](../setup/hardware/v2.5/kit/index.md) or [Device Assembly guide](../setup/hardware/v2.5/assembly/index.md)
+9. **Follow the build instructions**: Depending on the format you have chosen, start implementing by following the Kit Manufacturing guide or Device Assembly guide
 10. **Follow the operation instructions**: Now that you have successfully assembled the PlanktoScope, you can proceed to operation of the PlanktoScope by following the [Getting started](../operation/index.md) and [User interface](../operation/user-interface.md) instructions.
 11. **Final Test**: For a final test you can use for example pure cultures or a sample taken with a [Plankton net](../operation/sample-collection.md#plankton-net) from a surrounding waters.
 

--- a/documentation/docs/setup/hardware/index-noguides.md
+++ b/documentation/docs/setup/hardware/index-noguides.md
@@ -1,0 +1,3 @@
+# PlanktoScope Hardware
+
+You are viewing a copy of the PlanktoScope project documentation without the hardware setup guides, probably because you're viewing an offline, reduced-size copy of the PlanktoScope documentation served by your PlanktoScope. You should go to an [online copy of the PlanktoScope documentation](https://docs-edge.planktoscope.community) to find the hardware setup guides.

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -13,12 +13,12 @@ nav:
     - setup/index.md
     - Hardware:
       - setup/hardware/index.md
-      - v2.5:
-        - setup/hardware/v2.5/index.md
-        - Kit Production: setup/hardware/v2.5/kit/index.md
-        - Assembly: setup/hardware/v2.5/assembly/index.md
-      - v2.1:
-        - setup/hardware/v2.1/index.md
+      - v2.5: # poe(make-minimal): exclude
+        - setup/hardware/v2.5/index.md # poe(make-minimal): exclude
+        - Kit Production: setup/hardware/v2.5/kit/index.md # poe(make-minimal): exclude
+        - Assembly: setup/hardware/v2.5/assembly/index.md # poe(make-minimal): exclude
+      - v2.1: # poe(make-minimal): exclude
+        - setup/hardware/v2.1/index.md # poe(make-minimal): exclude
     - Software:
       - setup/software/index.md
       - Standard Installation: setup/software/standard-install.md

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -62,15 +62,29 @@ pillow = "10.0.1"
 mkdocs-git-revision-date-localized-plugin = "^1.2.1"
 
 [tool.poe.tasks]
+# Assets from outside the documentation directory
 clean-hardware-assets = "rm -rf docs/assets/hardware"  # FIXME: this command probably won't work on Windows
 import-hardware-assets = "cp -r ../hardware docs/assets/hardware"  # FIXME: this command probably won't work on Windows
 import-repo-assets = "cp ../software/CHANGELOG.md docs/reference/software/changelog.md"
 import-external-assets = ["clean-hardware-assets", "import-hardware-assets", "import-repo-assets"]
+
+# Image optimization
 optimize-png-photos = "imgp --convert --optimize --quality 95 --recurse --overwrite docs/images/assembly_guide/*.png"
 optimize-widths = "imgp --res 1200x0 --optimize --quality 95 --recurse --overwrite docs/images"
 optimize-compression = "imgp --eraseexif --optimize --progressive --quality 85 --recurse --overwrite docs/images"
+
+# Previews and standard builds
 preview = "mkdocs serve --dev-addr localhost:8000"
 build = "mkdocs build --clean --strict"
+
+# Minimal builds
+remove-hardware-setup-guides = "rm -rf docs/setup/hardware/v*"
+replace-hardware-setup-index = "mv docs/setup/hardware/index-noguides.md docs/setup/hardware/index.md"
+# Warning: this command should be run in GitHub Actions, but not on a developer computer! This is 
+# because it will delete files, and those deletions should never be committed to GitHub.
+make-minimal = ["remove-hardware-setup-guides", "replace-hardware-setup-index"]
+
+# Documentation checking
 build-check = "mkdocs build --clean --strict --no-directory-urls"
 check-links = "linkchecker --config .linkcheckerrc site"
 check = ["build-check", "check-links"]

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -80,9 +80,15 @@ build = "mkdocs build --clean --strict"
 # Minimal builds
 remove-hardware-setup-guides = "rm -rf docs/setup/hardware/v*"
 replace-hardware-setup-index = "mv docs/setup/hardware/index-noguides.md docs/setup/hardware/index.md"
+remove-nav-exclusions = "sed -i 's~^.* # poe(make-minimal): exclude$~~' mkdocs.yml"
 # Warning: this command should be run in GitHub Actions, but not on a developer computer! This is 
 # because it will delete files, and those deletions should never be committed to GitHub.
-make-minimal = ["remove-hardware-setup-guides", "replace-hardware-setup-index"]
+make-minimal = [
+  "remove-hardware-setup-guides",
+  "replace-hardware-setup-index",
+  "remove-hardware-setup-nav-headers",
+  "remove-hardware-setup-nav",
+]
 
 # Documentation checking
 build-check = "mkdocs build --clean --strict --no-directory-urls"

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -86,8 +86,7 @@ remove-nav-exclusions = "sed -i 's~^.* # poe(make-minimal): exclude$~~' mkdocs.y
 make-minimal = [
   "remove-hardware-setup-guides",
   "replace-hardware-setup-index",
-  "remove-hardware-setup-nav-headers",
-  "remove-hardware-setup-nav",
+  "remove-nav-exclusions",
 ]
 
 # Documentation checking

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -84,6 +84,7 @@ remove-nav-exclusions = "sed -i 's~^.* # poe(make-minimal): exclude$~~' mkdocs.y
 # Warning: this command should be run in GitHub Actions, but not on a developer computer! This is 
 # because it will delete files, and those deletions should never be committed to GitHub.
 make-minimal = [
+  "clean-hardware-assets",
   "remove-hardware-setup-guides",
   "replace-hardware-setup-index",
   "remove-nav-exclusions",


### PR DESCRIPTION
This PR attempts to help save space on the PlanktoScope SD card image by making it possible to replace the offline docs site available by default on the PlanktoScope with a smaller version of the docs site, which is smaller because all of the hardware setup guides (and their many images, which constitute most of the filesize of the container image for the offline docs site) are deleted from the smaller version of the docs site.

This PR only adds the systems to build the reduced-size version of the docs - it does not replace the full-size version of the docs with the reduced-size version in the default pallet provided with the PlanktoScope SD card image.