### PR TITLE
Add v2.5 hardware BOM to v2.5 kit production guide

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -8,6 +8,11 @@ on:
       - 'edge'
       - 'beta'
       - 'stable'
+    paths:
+      - 'documentation/**'
+      - 'hardware/**'
+      - 'software/CHANGELOG.md'
+      - '.github/workflows/documentation-build.yml'
     tags:
       - 'documentation/v*'
   pull_request:

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -8,15 +8,14 @@ on:
       - 'edge'
       - 'beta'
       - 'stable'
+    tags:
+      - 'documentation/v*'
+  pull_request:
     paths:
       - 'documentation/**'
       - 'hardware/**'
       - 'software/CHANGELOG.md'
       - '.github/workflows/documentation-build.yml'
-    tags:
-      - 'documentation/v*'
-  pull_request:
-  pull_request_review:
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/documentation-deploy-edge.yml
+++ b/.github/workflows/documentation-deploy-edge.yml
@@ -8,6 +8,8 @@ on:
       - 'edge'
     paths:
       - 'documentation/**'
+      - 'hardware/**'
+      - 'software/CHANGELOG.md'
       - '.github/workflows/documentation-deploy-edge.yml'
   workflow_dispatch:
 

--- a/documentation/docs/setup/hardware/v2.5/assembly/index.md
+++ b/documentation/docs/setup/hardware/v2.5/assembly/index.md
@@ -29,7 +29,7 @@ It is important to ensure that you have all of the necessary components before b
 | **X4**  | Raspberry PI HQ Camera Modul       |
 | **X5**  | Sandpaper                          |
 
-If any bags are missing, please go back to the BOM (Bill of Materials) and reorder the required components.
+If any bags are missing, please go back to the [BOM (Bill of Materials)](../../../../assets/hardware/v2.5/bom.csv) and reorder the required components.
 
 ## About this document
 

--- a/documentation/docs/setup/hardware/v2.5/kit/index.md
+++ b/documentation/docs/setup/hardware/v2.5/kit/index.md
@@ -10,8 +10,8 @@
 
 ### Manufacturing files
 
-| Files                                                               | Description                              |
-| ------------------------------------------------------------------- | ---------------------------------------- |
+| Files                                                                                | Description                              |
+| ------------------------------------------------------------------------------------ | ---------------------------------------- |
 | [PlanktoScope-Case.dxf](../../../../assets/hardware/v2.5/case/PlanktoScope-Case.dxf) | PlanktoScope Case export for CNC Milling |
 
 ### Tools
@@ -67,16 +67,16 @@ We use Rubio Monocoat Plus as a finishing product for Valchromat.
 Here is a step-by-step guide on how to configure the feed rate and the diameter of the end mill of a CNC milling machine for the production of a workpiece, using the specified tools and configuration:
 
 1. Select the appropriate end mill: The end mill should be selected based on the material and shape of the workpiece, as well as the desired level of precision. For this specific production, the following end mills will be used:
-
-   - 6mm end mill for straight flats
-   - 2mm end mill for inner contours
-   - 1mm end mill for small holes
+   
+    - 6mm end mill for straight flats
+    - 2mm end mill for inner contours
+    - 1mm end mill for small holes
 
 2. Determine the feed rate: The feed rate is the speed at which the end mill moves along the surface of the workpiece and is usually measured in millimeters per minute (mm/m). The appropriate feed rate will depend on the diameter of the end mill and the material and thickness of the workpiece. For this specific production, the following feed rates will be used:
-
-   - 1500mm/min for 1-2mm end mills
-   - 2500mm/min for 3mm end mills
-   - 3500mm/min for 6mm end mills
+   
+    - 1500mm/min for 1-2mm end mills
+    - 2500mm/min for 3mm end mills
+    - 3500mm/min for 6mm end mills
 
 3. Load the end mill: Once the appropriate end mill has been selected, it can be loaded onto the spindle of the CNC milling machine.
 
@@ -85,10 +85,10 @@ Here is a step-by-step guide on how to configure the feed rate and the diameter 
 5. Set the machine parameters: The feed rate and end mill diameter should be entered into the machine's control panel or included in the machining program.
 
 6. Begin machining: The machining process should be carried out in the following sequence:
-
-   - Mill the screw holes with a 2mm end mill and then with a 3mm end mill
-   - Mill the corners with a 2mm end mill
-   - Mill everything else with a 3mm end mill
+   
+    - Mill the screw holes with a 2mm end mill and then with a 3mm end mill
+    - Mill the corners with a 2mm end mill
+    - Mill everything else with a 3mm end mill
 
 By following these steps, you can properly configure the feed rate and the diameter of the end mill of a CNC milling machine for the production of a workpiece. It is important to follow the manufacturer's recommendations and guidelines for the specific CNC milling machine being used, as well as to use proper safety measures while operating the machine.
 
@@ -181,8 +181,8 @@ There are two main types of electronic components that can be mounted onto a PCB
 
 ### Manufacturing files
 
-| Files                                                                                         | Description                                   |
-| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Files                                                                                                          | Description                                   |
+| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
 | [Planktoscope-Hat-gerbers.zip](../../../../assets/hardware/v2.5/hat/Planktoscope-Hat-gerbers.zip)              | The exported Gerber files for PCB fabrication |
 | [Planktoscope-Hat-bom.csv](../../../../assets/hardware/v2.5/hat/assembly/Planktoscope-Hat-bom.csv)             | The list of used SMD components               |
 | [Planktoscope-Hat.pdf](../../../../assets/hardware/v2.5/hat/assembly/Planktoscope-Hat.pdf)                     | The SMD assembly footprints                   |
@@ -335,8 +335,8 @@ To ensure the quality of the produced PCB, request data validation from the cust
 
 ##### Thru-Hole parts
 
-| Files                                                                                                       | Description                     |
-| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| Files                                                                                                                        | Description                     |
+| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
 | [Planktoscope-Hat-bom-through-hole.csv](../../../../assets/hardware/v2.5/hat/assembly/Planktoscope-Hat-bom-through-hole.csv) | The list of used SMD components |
 
 !!! warning
@@ -581,6 +581,4 @@ Now insert the foam edge in to the case and glue it to the outer wall.
 
 <!-- ![all kit parts](images/XXXXX.jpg) -->
 
-Now divide all the components for a kit and pack it in the hard case.
-
----
+Now divide all the components for the kit, and pack it in the hard case. You can find the full list of components for the kit in the v2.5 hardware [BOM (Bill of Materials)](../../../../assets/hardware/v2.5/bom.csv). However, this BOM does not include ordering links, since such links will need to be different for each country. If you've customized the v2.5 hardware BOM for your own v2.5 PlanktoScope kit (e.g. by finding and adding part ordering links from suppliers in your country for each component), please share your custom BOM to our GitHub Discussions thread for [v2.5 Localized Hardware BOMs](https://github.com/PlanktoScope/PlanktoScope/discussions/297), so that other members of our community can learn from your work!

--- a/hardware/v2.5/bom.csv
+++ b/hardware/v2.5/bom.csv
@@ -1,35 +1,35 @@
-POS,QTY,PART NAME,PART MANUFACTURER,PART CODE,SPECIFICATIONS,DESIGNATORS,
-1,1,Hard Case,Tectake,402870,Type 2,n/a,
-2,1,Rectangular Capillary,CM Scientific,3530-050,0.30 x 3.00mm ID,n/a,
-3,4,Standoff M2.5 x 0.45 - 6mm (FM2101-2545-SS),Fascomp,FM2101-2545-SS,Standoff M2.5 x 0.45 - 6mm (FM2101-2545-SS),A1,
-4,4,Standoff M2.5 x 0.45 - 15mm (FM2110-2545-SS) (FM2110-2545-SS),Fascomp,FM2110-2545-SS,Standoff M2.5 x 0.45 - 15mm (FM2110-2545-SS) (FM2110-2545-SS),A2,
-5,4,Standoff M2.5 x 0.45 - 16mm (FM2111-2545-SS) (FM2111-2545-SS),Fascomp,FM2111-2545-SS,Standoff M2.5 x 0.45 - 16mm (FM2111-2545-SS) (FM2111-2545-SS),A3,
-6,8,M2.5X5 INOX A2 CHC DIN 912,BafaSa,CHI2.505,M2.5X5 INOX A2 CHC DIN 912,A4,
-7,7,M2.5X10 INOX A2 CHC DIN 912,BafaSa,CHI2.510,M2.5X10 INOX A2 CHC DIN 912,A5,
-8,32,M3X12 INOX A2 BHC BASE ISO 7380-2,BafaSa,BHCEI03012,M3X12 INOX A2 BHC BASE ISO 7380-2,A6,
-9,4,Silicone adhesive pads,,,Silicone adhesive pads,A7,
-10,2,"Barbed to Female Luer Adapter 1/16""",Darwin Microfluidics,CIL-P-857,"Barbed to Female Luer Adapter 1/16""",D1,
-11,1,"Barbed to Male Luer Adapter 1/16""",Darwin Microfluidics,CIL-P-850,"Barbed to Male Luer Adapter 1/16""",D3,
-12,1,Tube n°3,PontonZ,,Tube n°3,D4,
-13,1,Tube n°4,PontonZ,,Tube n°4,D5,
-14,1,Mini Bubbling USB,,,Mini Bubbling USB,E1,
-15,1,Peristalic pump,Kamoer,KAS B12 SF,ID 1.5 OD 3.5,F1,
-16,3,FlowCell,n/a,n/a,300um,F4,
-17,2,Reinforced Linear Stepper Motor,Motor Kindom Store,SUS303,Reinforced Linear Stepper Motor,G1,
-18,1,Heat Sink Kit for Raspberry Pi 4B (110991327),Seeed Studio,110991327,Heat Sink Kit for Raspberry Pi 4B (110991327),H1,
-19,1,Custom HAT,planktoscope,Custom HAT,Custom HAT,I1,
-20,1,"M12 LENS 25MM 5MP 1/2""",Fulekan,Lens_25MM_5MP_1/2,"M12 LENS 25MM 5MP 1/2""",J1,https://de.aliexpress.com/item/32463065187.html?spm=a2g0o.cart.0.0.45304ae4aVqKCM&mp=1&gatewayAdapt=glo2deu
-21,2,M12 Lens Locking Ring,Fulekan,,M12 Lens Locking Ring,J2,https://de.aliexpress.com/item/1005004089156032.html?spm=a2g0o.cart.0.0.53c44ae4N5Frvn&mp=1&gatewayAdapt=glo2deu
-22,1,"M12 LENS 16MM 5MP 1/2.5""",Fulekan,Lens_16MM_5MP_1/2.5,"M12 LENS 16MM 5MP 1/2.5""",J3,https://de.aliexpress.com/item/32463510661.html?spm=a2g0o.cart.0.0.45304ae4aVqKCM&mp=1&gatewayAdapt=glo2deu
-23,1,LED - Adafruit (754),Adafruit Industries,754,LED - Adafruit (754),J4,
-24,1,Sd Card 128Gb (SDSQXA1-128G-GN6MA),SanDisk,SDSQXA1-128G-GN6MA,Sd Card 128Gb (SDSQXA1-128G-GN6MA),K1,
-25,1,LED to HAT wires,planktoscope,,LED to HAT wires,K2,
-26,1,DC Power Jack Shield Front Pnl Mnt 2.1mm (721AFMS),Switchcraft,721AFMS,DC Power Jack Shield Front Pnl Mnt 2.1mm (721AFMS),K3,
-27,2,Falcon tube 50ml,BITEFU,bitefu006,Falcon tube 50ml,M1,
-28,1,BD Biocoat Luer-Lock Disposable Syringes - 20 mL,Darwin Microfluidics,CO-07944-16,BD Biocoat Luer-Lock Disposable Syringes - 20 mL,M2,
-29,1,Structure V2.5,PontonZ,,Structure V2.5,S,
-30,1,RASPBERRY PI 4 MODEL B (RPI4-MODBP-4GB),Raspberry Pi,RPI4-MODBP-4GB,RASPBERRY PI 4 MODEL B (RPI4-MODBP-4GB),X1,
-31,1,Raspberry Pi HQ Camera (SC0261),Raspberry Pi,SC0261,Raspberry Pi HQ Camera (SC0261),X4,
-32,1,AC ADAPTOR 12V 4A 2.1MM (SW3126B),Stontronics,SW3126B,AC ADAPTOR 12V 4A 2.1MM (SW3126B),X5,
-33,32,Square Nuts M3X5.5X1.8 INOX A2 DIN 562,BafaSa,562I3,Square Nuts M3X5.5X1.8 INOX A2 DIN 562,XXX,
-34,30,Neodyme Circular Magnet 5mm x5mm,First4magnets,F641-25,Neodyme Circular Magnet 5mm x5mm,XXX1,
+"#","Comments","Part/BOM Name","BOM Qty","Designators","Manufacturer","MPN","Part"
+"1","","Case Tectake Type 2","1","","Tectake","402870","Case Tectake Type 2"
+"2","","Hollow Rectangular Capillary 0.30 x 3.00mm ID","1","","CM Scientific","3530-050","Hollow Rectangular Capillary 0.30 x 3.00mm ID"
+"3","","Standoff M2.5 x 0.45 - 6mm (FM2101-2545-SS)","4","A1","Fascomp","FM2101-2545-SS","Standoff M2.5 x 0.45 - 6mm (FM2101-2545-SS)"
+"4","","Standoff M2.5 x 0.45 - 15mm (FM2110-2545-SS) (FM2110-2545-SS)","4","A2","Fascomp","FM2110-2545-SS","Standoff M2.5 x 0.45 - 15mm (FM2110-2545-SS) (FM2110-2545-SS)"
+"5","","Standoff M2.5 x 0.45 - 16mm (FM2111-2545-SS) (FM2111-2545-SS)","4","A3","Fascomp","FM2111-2545-SS","Standoff M2.5 x 0.45 - 16mm (FM2111-2545-SS) (FM2111-2545-SS)"
+"6","","M2.5X5 INOX A2 CHC DIN 912","8","A4","BafaSa","CHI2.505","M2.5X5 INOX A2 CHC DIN 912"
+"7","","M2.5X10 INOX A2 CHC DIN 912","7","A5","BafaSa","CHI2.510","M2.5X10 INOX A2 CHC DIN 912"
+"8","","M3X12 INOX A2 BHC BASE ISO 7380-2","32","A6","BafaSa","BHCEI03012","M3X12 INOX A2 BHC BASE ISO 7380-2"
+"9","","Silicone adhesive pads","4","A7","","","Silicone adhesive pads"
+"10","","Barbed to Female Luer Adapter 1/16""","2","D1","Darwin Microfluidics","CIL-P-854","Barbed to Female Luer Adapter 1/16"""
+"11","","Barbed to Male Luer Adapter 1/16""","1","D3","Darwin Microfluidics","CIL-P-850","Barbed to Male Luer Adapter 1/16"""
+"12","","Tube n°3","1","D4","PontonZ","","Tube n°3"
+"13","","Tube n°4","1","D5","PontonZ","","Tube n°4"
+"14","","Mini Bubbling USB","1","E1","","","Mini Bubbling USB"
+"15","","Kamoer  Peristalic pump KAS B12 SF - ID 1.5 OD 3.5","1","F1","Kamoer","KAS B12 SF","Kamoer  Peristalic pump KAS B12 SF - ID 1.5 OD 3.5"
+"16","","FlowCell 300um","3","F4","planktoscope","FlowCell 300um","FlowCell 300um"
+"17","","Reinforced Linear Stepper Motor","2","G1","Motor Kindom Store","SUS303","Reinforced Linear Stepper Motor"
+"18","","Heat Sink Kit for Raspberry Pi 4B (110991327)","1","H1","Seeed Studio","110991327","Heat Sink Kit for Raspberry Pi 4B (110991327)"
+"19","","Custom HAT","1","I1","planktoscope","Custom HAT","Custom HAT"
+"20","","M12 LENS 25MM 5MP 1/2""","1","J1","Fulekan","Lens_25MM_5MP_1/2","M12 LENS 25MM 5MP 1/2"""
+"21","","M12 Lens Locking Ring","2","J2","Fulekan","","M12 Lens Locking Ring"
+"22","","M12 LENS 16MM 5MP 1/2.5""","1","J3","Fulekan","Lens_16MM_5MP_1/2.5","M12 LENS 16MM 5MP 1/2.5"""
+"23","","LED - Adafruit (754)","1","J4","Adafruit Industries","754","LED - Adafruit (754)"
+"24","","Sd Card 128Gb (SDSQXA1-128G-GN6MA)","1","K1","SanDisk","SDSQXA1-128G-GN6MA","Sd Card 128Gb (SDSQXA1-128G-GN6MA)"
+"25","","LED to HAT wires","1","K2","planktoscope","","LED to HAT wires"
+"26","","DC Power Jack Shield Front Pnl Mnt 2.1mm (721AFMS)","1","K3","Switchcraft","721AFMS","DC Power Jack Shield Front Pnl Mnt 2.1mm (721AFMS)"
+"27","","Falcon tube 50ml","2","M1","BITEFU","bitefu006","Falcon tube 50ml"
+"28","","BD Biocoat Luer-Lock Disposable Syringes - 20 mL","1","M2","Darwin Microfluidics","CO-07944-16","BD Biocoat Luer-Lock Disposable Syringes - 20 mL"
+"29","","Structure V2.5","1","S","PontonZ","","Structure V2.5"
+"30","","RASPBERRY PI 4 MODEL B (RPI4-MODBP-4GB)","1","X1","Raspberry Pi","RPI4-MODBP-4GB","RASPBERRY PI 4 MODEL B (RPI4-MODBP-4GB)"
+"31","","Raspberry Pi HQ Camera (SC0261)","1","X4","Raspberry Pi","SC0261","Raspberry Pi HQ Camera (SC0261)"
+"32","","AC ADAPTOR 12V 4A 2.1MM (SW3126B)","1","X5","Stontronics","SW3126B","AC ADAPTOR 12V 4A 2.1MM (SW3126B)"
+"33","","Square Nuts M3X5.5X1.8 INOX A2 DIN 562","32","XXX","BafaSa","562I3","Square Nuts M3X5.5X1.8 INOX A2 DIN 562"
+"34","","Neodyme Circular Magnet 5mm x5mm","30","XXX1","First4magnets","F641-25","Neodyme Circular Magnet 5mm x5mm"


### PR DESCRIPTION
This PR adds the v2.5 hardware BOM (uploaded by @tpollina to the PlanktoScope Slack at https://planktoscope.slack.com/archives/C03KZ3V564X/p1667487401679529 ) to the v2.5 hardware setup guide. The BOM is already in the repo at `/hardware/v2.5/bom.csv`, but it had not been called out in the docs site. This PR adds the necessary links and descriptions.

This PR also tries to update the GitHub Actions workflows for building the docs site so that they don't run on pushes to PRs which don't modify files affecting the docs site.