### PR TITLE
Automatically deploy stable versions of the docs site to docs.planktoscope.community

### DIFF
--- a/.github/workflows/documentation-deploy-stable.yml
+++ b/.github/workflows/documentation-deploy-stable.yml
@@ -1,15 +1,15 @@
-name: Deploy documentation (beta release channel)
+name: Deploy documentation (stable release channel)
 
 on:
   push:
     branches:
-      - 'documentation/beta'
+      - 'documentation/stable'
   workflow_dispatch:
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest
 # queued. But do not cancel in-progress runs - we want these deploymeents to complete.
 concurrency:
-  group: "docs-beta-deploy"
+  group: "docs-stable-deploy"
   cancel-in-progress: false
 
 defaults:
@@ -19,8 +19,8 @@ defaults:
 jobs:
   deploy:
     environment:
-      name: documentation-beta
-      url: https://docs-beta.planktoscope.community
+      name: documentation-stable
+      url: https://docs.planktoscope.community
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,9 +42,6 @@ jobs:
 
       - name: Import external assets
         run: poetry -C ./documentation/ run poe --root ./documentation/ import-external-assets
-
-      - name: Set release channel
-        run: poetry -C ./documentation/ run poe --root ./documentation/ set-beta-release-channel
 
       - name: Build documentation
         run: poetry -C ./documentation/ run poe --root ./documentation/ build

--- a/documentation/docs/setup/hardware/index-noguides.md
+++ b/documentation/docs/setup/hardware/index-noguides.md
@@ -1,3 +1,3 @@
 # PlanktoScope Hardware
 
-You are viewing a copy of the PlanktoScope project documentation without the hardware setup guides, probably because you're viewing an offline, reduced-size copy of the PlanktoScope documentation served by your PlanktoScope. You should go to an [online copy of the PlanktoScope documentation](https://docs-edge.planktoscope.community) to find the hardware setup guides.
+You are viewing a copy of the PlanktoScope project documentation without the hardware setup guides, probably because you're viewing an offline, reduced-size copy of the PlanktoScope documentation served by your PlanktoScope. You should go to an [online copy of the PlanktoScope documentation](https://docs.planktoscope.community) to find the hardware setup guides.

--- a/documentation/docs/setup/software/nonstandard-install.md
+++ b/documentation/docs/setup/software/nonstandard-install.md
@@ -56,9 +56,9 @@ Next, configure your Raspberry Pi to get internet access - your Raspberry Pi wil
 
 ## Set up the PlanktoScope software distribution
 
-Depending on whether you're installing the software on a PlanktoScope with the custom PlanktoScope HAT (which is the standard HAT on v2.3 hardware and later) or with the Adafruit Stepper Motor HAT (which is the standard HAT on v2.1 hardware), you will need to replace, you will need to adjust the commands below. Specifically, if you're installing the software for a PlanktoScope with the Adafruit Stepper Motor HAT, you will need to replace the word `pscopehat` with the word `adafruithat` in any of the commands below.
-
 ### Run the installation script
+
+Depending on whether you're installing the software on a PlanktoScope with the custom PlanktoScope HAT (which is the standard HAT on v2.3 hardware and later) or with the Adafruit Stepper Motor HAT (which is the standard HAT on v2.1 hardware), you will need to adjust the commands below. Specifically, if you're installing the software for a PlanktoScope with the Adafruit Stepper Motor HAT, you will need to replace the word `pscopehat` with the word `adafruithat` in any of the commands below.
 
 Log in to your Raspberry Pi and (if you installed a version of Raspberry Pi OS with a graphical desktop) open a terminal. Then type in one of the following commands, for either the latest beta prerelease of the PlanktoScope software distribution, the latest stable release, or the latest development version:
 
@@ -102,8 +102,6 @@ Note that you can also choose to install the PlanktoScope software from some oth
 wget -qO - https://install.planktoscope.community/distro.sh \
   | sh -s -- --help
 ```
-
-
 
 ### Wait for installation to finish
 

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -24,8 +24,7 @@ license = "CC-BY-SA-4.0"
 readme = "README.md"
 homepage = "https://www.planktoscope.org"
 repository = "https://github.com/PlanktoScope/PlanktoScope"
-# FIXME: once we have the docs up at docs.planktoscope.org, we should update this URL
-documentation = "https://docs-edge.planktoscope.community"
+documentation = "https://docs.planktoscope.community"
 keywords = ["documentation", "planktoscope"]
 classifiers = [
   "Intended Audience :: Science/Research",


### PR DESCRIPTION
This PR makes progress on #144 by setting up a GitHub Actions workflow to automatically deploy any pushes to the `documentation/stable` branch to a new repo at [github.com/PlanktoScope/docs.planktoscope.community](https://github.com/PlanktoScope/docs.planktoscope.community), which publishes the site at https://docs.planktoscope.community.

This PR also unlinks the `beta` branch from automatic deployments to docs-beta.planktoscope.community, since the beta branch is used for beta versions of the software, which might evolve on a different timeline than the documentation. So from now on we will just use the `documentation/beta` branch for deployments to docs-beta.planktoscope.community.