### PR TITLE
Fix the names of deployment env secrets for SSH deploy keys

### DIFF
--- a/.github/workflows/documentation-deploy-beta.yml
+++ b/.github/workflows/documentation-deploy-beta.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Push to ${{ vars.REPOSITORY_NAME }}
         uses: cpina/github-action-push-to-another-repository@main
         env:
-          SSH_DEPLOY_KEY: ${{ secrets.DOCS_BETA_SSH_DEPLOY_KEY }}
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:
           source-directory: documentation/site/
           destination-github-username: PlanktoScope

--- a/.github/workflows/documentation-deploy-stable.yml
+++ b/.github/workflows/documentation-deploy-stable.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Push to ${{ vars.REPOSITORY_NAME }}
         uses: cpina/github-action-push-to-another-repository@main
         env:
-          SSH_DEPLOY_KEY: ${{ secrets.DOCS_BETA_SSH_DEPLOY_KEY }}
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:
           source-directory: documentation/site/
           destination-github-username: PlanktoScope


### PR DESCRIPTION
This PR attempts to fix some errors in the GitHub Actions workflow files which had slipped through in #298 and #299.