### PR TITLE
Bump version number of the docs package to 2023.9.0b3

### DIFF
--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -2,7 +2,7 @@
 name = "planktoscope-docs"
 # Note: PEP 440 requires pre-releases to be formatted like "2023.7.0b0" rather than
 # "2023.7.0-beta.0", which is different from the Semantic Versioning schema
-version = "2023.9.0b2"
+version = "2023.9.0b3"
 description = "Documentation for the PlanktoScope project"
 # For simplicity, we follow the definition of "Maintainer" from
 # https://opensource.guide/how-to-contribute/#anatomy-of-an-open-source-project , which says:


### PR DESCRIPTION
This PR is part of the preparation for the v2023.9.0-beta.2 software release.