### PR TITLE
Enable mkdocs-material's privacy plugin

### DIFF
--- a/documentation/.gitignore
+++ b/documentation/.gitignore
@@ -1,1 +1,5 @@
+# Built mkdocs site
 site/
+
+# Cache for mkdocs-material plugins
+.cache/

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -96,8 +96,7 @@ plugins:
   - glightbox
   - minify:
       minify_html: true
-  # FIXME: enable the privacy plugin
-  #- privacy
+  - privacy
   - social:
       enabled: !ENV [DOCS_DEPLOY, false]
   - search

--- a/documentation/poetry.lock
+++ b/documentation/poetry.lock
@@ -692,13 +692,13 @@ pyyaml = "*"
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.0"
+version = "9.5.1"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.0-py3-none-any.whl", hash = "sha256:47323c9943756ced14487d0607caa283e350e8fd4c724b224bd69ccb0b0731f2"},
-    {file = "mkdocs_material-9.5.0.tar.gz", hash = "sha256:f8f9ccb526bd8a8ac2e5ec2e64e1a167cfb53cf6a84c8924dbb607f0a70e74ae"},
+    {file = "mkdocs_material-9.5.1-py3-none-any.whl", hash = "sha256:2e01249bc41813afe2479a4a659f8ba899c3355ccaf9310b5b782952df9c1dea"},
+    {file = "mkdocs_material-9.5.1.tar.gz", hash = "sha256:7ec5d20ed5eee97bb090823a33b33e177ad0704d74bad5937b53acca571ddb3d"},
 ]
 
 [package.dependencies]
@@ -1368,4 +1368,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "b620a5352453b61e76d2fdd7b77a2f959e62320832ff724c00a32be5ccd68a54"
+content-hash = "79bdf54d38ed2d163cfdcdf674a9d76ea6cfd562a5e6e87a2afc9abeed2a312e"

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -43,7 +43,7 @@ mkdocs-charts-plugin = "^0.0.10"
 mkdocs-glightbox = "^0.3.5"
 mkdocs-macros-plugin = "^1.0.5"
 mkdocs-markdownextradata-plugin = "^0.2.5"
-mkdocs-material = "^9.5.0"
+mkdocs-material = "^9.5.1"
 mkdocs-minify-plugin = "^0.7.1"
 mkdocs-redirects = "^1.2.0"
 # Note: we do not allow the mkdocs-table-reader-plugin in this project because it pulls in a


### PR DESCRIPTION
This PR bumps the installed version of mkdocs-material to 9.5.1 so that we can enable mkdocs-material's built-in privacy plugin. The privacy plugin allows us to vendor all external assets into our static site, for better offline deployment  (though we still assume that offline deployments of the docs site are served with a web server like Caddy rather than being downloaded as a `.tar.gz` or `.zip` file). The privacy plugin also simplifies GDPR compliance, though that's not the biggest benefit of the plugin for our project.