### PR TITLE
Promote v2023.9.0-beta.2 to v2023.9.0

### DIFF
--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -5,7 +5,7 @@
 
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 forklift_version="0.4.0"
-pallet_version="v2023.9.0-beta.2"
+pallet_version="v2023.9.0"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C $HOME/.local/bin -xz forklift

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -32,7 +32,7 @@ python3 -m pip install --user pipx==1.2.0
 python3 -m pipx ensurepath
 
 # Download device-backend monorepo
-backend_version="v2023.9.0-beta.2" # this should be either a version tag, branch name, or commit hash
+backend_version="v2023.9.0" # this should be either a version tag, branch name, or commit hash
 git clone https://github.com/PlanktoScope/device-backend $HOME/device-backend --no-checkout --filter=blob:none
 git -C $HOME/device-backend checkout --quiet $backend_version
 

--- a/software/node-red-dashboard/package.json
+++ b/software/node-red-dashboard/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "planktoscope",
-    "description": "PlanktoScope main software project",
-    "version": "2023.9.0-beta.2",
+    "name": "planktoscope-node-red-dashboard",
+    "description": "PlanktoScope graphical user interface",
+    "version": "2023.9.0",
     "dependencies": {
         "node-red-contrib-dir2files": "^0.3.0",
         "node-red-contrib-gpsd": "^1.0.4",


### PR DESCRIPTION
To test this PR, run the following command on a fresh installation of Raspberry Pi OS bullseye (replacing `pscopehat` with `adafruithat` if installing on an Adafruit HAT-based PlanktoScope):
```
wget -qO - https://install.planktoscope.community/distro.sh | \
  sh -s -- -y -v release/bump-version -H pscopehat
```
Or, for a more reproducible but less convenient command which will work the same even if/when the install script is updated in the future, run:
```
wget -qO - https://raw.githubusercontent.com/PlanktoScope/install.planktoscope.community/v2023.9.0/distro.sh | \
  sh -s -- -y -t hash -v ea4e78c -H pscopehat
```