### PR TITLE
Fix some issues with running the distro setup scripts on RPi OS 12 (bookworm)

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -9,6 +9,24 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Added
+
+- (System: networking) Added `lynx` as an alternative terminal web browser to `w3m` for trying to work through captive portals on the Cockpit terminal.
+
+### Changed
+
+- (System: security) `ufw` has been replaced with `firewalld`. However, firewalld has not yet been properly configured.
+
+### Removed
+
+- (System: administration) Removed `cockpit-storaged`, which was not useful anyways and had pulled in many unneeded dependencies.
+- (System: setup) Removed some unnecessary `apt-get update` commands for a very minor speed-up in the distro setup process.
+
+### Fixed
+
+- (System) Boot time has been made faster by 30 seconds.
+- (System) The base OS setup scripts now run without errors on both the 32-bit and 64-bit versions of Raspberry Pi OS 12 (bookworm). However, setup of the PlanktoScope applications still fails with errors on bookworm and on 64-bit versions of the Raspberry Pi OS.
+
 ## v2023.9.0 - 2023-12-30
 
 (this release involves no changes from v2023.9.0-beta.2; it's just a promotion of v2023.9.0-beta.2 to a stable release)

--- a/software/distro/setup/base-os/networking/config.sh
+++ b/software/distro/setup/base-os/networking/config.sh
@@ -8,6 +8,9 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 # Install dependencies
 sudo apt-get install -y firewalld dnsmasq hostapd
 
+# Restart docker to integrate with firewalld
+sudo systemctl restart docker
+
 # Force reinitialization of the machine ID
 sudo bash -c "echo \"uninitialized\" > /etc/machine-id"
 

--- a/software/distro/setup/base-os/networking/config.sh
+++ b/software/distro/setup/base-os/networking/config.sh
@@ -6,7 +6,6 @@
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Install dependencies
-sudo apt-get update -y
 sudo apt-get install -y firewalld dnsmasq hostapd
 
 # Force reinitialization of the machine ID

--- a/software/distro/setup/base-os/networking/config.sh
+++ b/software/distro/setup/base-os/networking/config.sh
@@ -7,7 +7,7 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Install dependencies
 sudo apt-get update -y
-sudo apt-get install -y ufw dnsmasq hostapd
+sudo apt-get install -y firewalld dnsmasq hostapd
 
 # Force reinitialization of the machine ID
 sudo bash -c "echo \"uninitialized\" > /etc/machine-id"
@@ -24,7 +24,7 @@ sudo raspi-config nonint do_ssh 0
 sudo rm -f /etc/ssh/ssh_host_*
 sudo systemctl enable regenerate_ssh_host_keys.service
 
-# TODO: add basic ufw settings
+# TODO: add basic firewalld settings
 
 # Change hostapd settings
 # FIXME: the config file sets a country code which needs to be updated for local countries (and

--- a/software/distro/setup/base-os/networking/config.sh
+++ b/software/distro/setup/base-os/networking/config.sh
@@ -8,6 +8,10 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 # Install dependencies
 sudo apt-get install -y firewalld dnsmasq hostapd
 
+# Disable firewalld for now
+# FIXME: enable firewalld and set up firewall rules
+sudo systemctl disable firewalld --now
+
 # Restart docker to integrate with firewalld
 sudo systemctl restart docker
 

--- a/software/distro/setup/base-os/networking/etc/systemd/system/autohotspot.service
+++ b/software/distro/setup/base-os/networking/etc/systemd/system/autohotspot.service
@@ -1,8 +1,12 @@
 [Unit]
 Description=Automatic generation of a wireless AP (wifi hotspot) when no known wifi networks are found
 Wants=enable-interface-forwarding.service
+Wants=enable-interface-forwarding.service
+After=docker.service
+
 [Service]
 Type=oneshot
 ExecStart=/home/pi/.local/bin/autohotspot.sh
+
 [Install]
-WantedBy=multi-user.target
+WantedBy=network-online.target

--- a/software/distro/setup/base-os/networking/etc/systemd/system/autohotspot.service
+++ b/software/distro/setup/base-os/networking/etc/systemd/system/autohotspot.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Automatic generation of a wireless AP (wifi hotspot) when no known wifi networks are found
 Wants=enable-interface-forwarding.service
+After=enable-interface-forwarding.service
+Before=network-online.target
+# Delay the wifi hotspot until we're ready to launch containerized network services:
 After=docker.service
 
 [Service]
@@ -9,4 +12,3 @@ ExecStart=/home/pi/.local/bin/autohotspot.sh
 
 [Install]
 WantedBy=network-online.target
-WantedBy=multi-user.target

--- a/software/distro/setup/base-os/networking/etc/systemd/system/autohotspot.service
+++ b/software/distro/setup/base-os/networking/etc/systemd/system/autohotspot.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Automatic generation of a wireless AP (wifi hotspot) when no known wifi networks are found
 Wants=enable-interface-forwarding.service
-Wants=enable-interface-forwarding.service
 After=docker.service
 
 [Service]
@@ -10,3 +9,4 @@ ExecStart=/home/pi/.local/bin/autohotspot.sh
 
 [Install]
 WantedBy=network-online.target
+WantedBy=multi-user.target

--- a/software/distro/setup/base-os/networking/etc/systemd/system/autohotspot.service
+++ b/software/distro/setup/base-os/networking/etc/systemd/system/autohotspot.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Automatic generation of a wireless AP (wifi hotspot) when no known wifi networks are found
-After=multi-user.target
+Wants=enable-interface-forwarding.service
 [Service]
 Type=oneshot
 ExecStart=/home/pi/.local/bin/autohotspot.sh

--- a/software/distro/setup/base-os/networking/etc/systemd/system/enable-interface-forwarding.service
+++ b/software/distro/setup/base-os/networking/etc/systemd/system/enable-interface-forwarding.service
@@ -8,4 +8,3 @@ ExecStart=/home/pi/.local/bin/enable-interface-forwarding.sh
 
 [Install]
 WantedBy=multi-user.target
-WantedBy=autohotspot.service

--- a/software/distro/setup/base-os/networking/etc/systemd/system/enable-interface-forwarding.service
+++ b/software/distro/setup/base-os/networking/etc/systemd/system/enable-interface-forwarding.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Enable forwarding of packets between eth0 and wlan0
-Before=network.target
 
 [Service]
 Type=oneshot

--- a/software/distro/setup/base-os/platform-hardware/config.sh
+++ b/software/distro/setup/base-os/platform-hardware/config.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -eux
 # The platform hardware configuration is for configuration specific to the underlying compute
 # platform used to run the operating system. Currently the only supported platform hardware is the
-# Raspberry Pi 4. Hopefully, in the future other platforms will also be supported - in which case
-# alternative OS build scripts will be needed for configuration.
+# Raspberry Pi 4 running Raspberry Pi OS 11 or newer.
+# Hopefully, in the future other platforms will also be supported - in which case alternative OS
+# build scripts will be needed for configuration.
 
 # Note: in general, 0 represents "success/yes/selected", while 1 represents "failed/no/unselected",
 # but there is no consistent meaning. Partial documentation of raspi-commands is available at
@@ -20,8 +21,13 @@ sudo raspi-config nonint do_i2c 0
 # The following command enables the serial port and serial port console.
 # do_serial_cons and do_serial_hw are needed for Raspberry Pi OS 12 (bookworm) and above, while
 # do_serial is needed for Raspberry Pi OS (bullseye).
-sudo raspi-config nonint do_serial_hw 0 || sudo raspi-config nonint do_serial 0
-sudo raspi-config nonint do_serial_cons 0 || sudo raspi-config nonint do_serial 0
+DISTRO_VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID")"
+if [ $DISTRO_VERSION_ID -ge 12 ]; then # Support Raspberry Pi OS 12 (bookworm)
+  sudo raspi-config nonint do_serial_hw 0
+  sudo raspi-config nonint do_serial_cons 0
+else # Support Raspberry Pi OS 11 (bullseye)
+  sudo raspi-config nonint do_serial 0
+fi
 
 # The following command enables the camera on the 32-bit Raspberry Pi OS (ARMv7):
 sudo raspi-config nonint do_camera 0
@@ -29,4 +35,8 @@ sudo raspi-config nonint do_camera 0
 sudo raspi-config nonint do_legacy 0
 
 # The following command sets the GPU memory to 256:
-sudo raspi-config nonint do_memory_split 256 || echo "GPU memory split cannot be changed on this platform."
+if [ $DISTRO_VERSION_ID -ge 12 ]; then # Support Raspberry Pi OS 12 (bookworm)
+  echo "GPU memory split cannot be changed on this platform."
+else # Support Raspberry Pi OS 11 (bullseye)
+  sudo raspi-config nonint do_memory_split 256
+fi

--- a/software/distro/setup/base-os/platform-hardware/config.sh
+++ b/software/distro/setup/base-os/platform-hardware/config.sh
@@ -34,6 +34,9 @@ sudo raspi-config nonint do_camera 0
 # The following command enables legacy camera support on the 64-bit Raspberry Pi OS (ARM64):
 sudo raspi-config nonint do_legacy 0
 
+# FIXME: remove this section entirely, to improve performance on bullseye.
+# Refer to https://www.raspberrypi.com/documentation/computers/legacy_config_txt.html#gpu_mem
+# for rationale. Note that we might need to first replace raspimjpeg with picamera2.
 # The following command sets the GPU memory to 256:
 if [ $DISTRO_VERSION_ID -ge 12 ]; then # Support Raspberry Pi OS 12 (bookworm)
   echo "GPU memory split cannot be changed on this platform."

--- a/software/distro/setup/base-os/platform-hardware/config.sh
+++ b/software/distro/setup/base-os/platform-hardware/config.sh
@@ -17,8 +17,11 @@
 sudo raspi-config nonint do_spi 0
 sudo raspi-config nonint do_i2c 0
 
-# The following command enables the serial port console.
-sudo raspi-config nonint do_serial 0
+# The following command enables the serial port and serial port console.
+# do_serial_cons and do_serial_hw are needed for Raspberry Pi OS 12 (bookworm) and above, while
+# do_serial is needed for Raspberry Pi OS (bullseye).
+sudo raspi-config do_serial_hw 0 || sudo raspi-config nonint do_serial 0
+sudo raspi-config do_serial_cons 0 || sudo raspi-config nonint do_serial 0
 
 # The following command enables the camera on the 32-bit Raspberry Pi OS (ARMv7):
 sudo raspi-config nonint do_camera 0

--- a/software/distro/setup/base-os/platform-hardware/config.sh
+++ b/software/distro/setup/base-os/platform-hardware/config.sh
@@ -20,8 +20,8 @@ sudo raspi-config nonint do_i2c 0
 # The following command enables the serial port and serial port console.
 # do_serial_cons and do_serial_hw are needed for Raspberry Pi OS 12 (bookworm) and above, while
 # do_serial is needed for Raspberry Pi OS (bullseye).
-sudo raspi-config do_serial_hw 0 || sudo raspi-config nonint do_serial 0
-sudo raspi-config do_serial_cons 0 || sudo raspi-config nonint do_serial 0
+sudo raspi-config nonint do_serial_hw 0 || sudo raspi-config nonint do_serial 0
+sudo raspi-config nonint do_serial_cons 0 || sudo raspi-config nonint do_serial 0
 
 # The following command enables the camera on the 32-bit Raspberry Pi OS (ARMv7):
 sudo raspi-config nonint do_camera 0

--- a/software/distro/setup/base-os/platform-hardware/config.sh
+++ b/software/distro/setup/base-os/platform-hardware/config.sh
@@ -29,4 +29,4 @@ sudo raspi-config nonint do_camera 0
 sudo raspi-config nonint do_legacy 0
 
 # The following command sets the GPU memory to 256:
-sudo raspi-config nonint do_memory_split 256
+sudo raspi-config nonint do_memory_split 256 || echo "GPU memory split cannot be changed on this platform."

--- a/software/distro/setup/base-os/tools/etc/systemd/system/docker.service
+++ b/software/distro/setup/base-os/tools/etc/systemd/system/docker.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+# Remove dependency on network-online.target
+After=network.target docker.socket firewalld.service containerd.service time-set.target
+Wants=network.target containerd.service
+Requires=docker.socket
+
+[Service]
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+ExecReload=/bin/kill -s HUP $MAINPID
+TimeoutStartSec=0
+RestartSec=2
+Restart=always
+
+# Note that StartLimit* options were moved from "Service" to "Unit" in systemd 229.
+# Both the old, and new location are accepted by systemd 229 and up, so using the old location
+# to make them work for either version of systemd.
+StartLimitBurst=3
+
+# Note that StartLimitInterval was renamed to StartLimitIntervalSec in systemd 230.
+# Both the old, and new name are accepted by systemd 230 and up, so using the old name to make
+# this option work for either version of systemd.
+StartLimitInterval=60s
+
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+
+# Comment TasksMax if your systemd version does not support it.
+# Only systemd 226 and above support this option.
+TasksMax=infinity
+
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+OOMScoreAdjust=-500
+
+[Install]
+WantedBy=multi-user.target

--- a/software/distro/setup/base-os/tools/etc/systemd/system/docker.service.d/override.conf
+++ b/software/distro/setup/base-os/tools/etc/systemd/system/docker.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+# Don't wait for network-online.target, since that takes a long time
+After=docker.socket firewalld.service containerd.service time-set.target

--- a/software/distro/setup/base-os/tools/etc/systemd/system/docker.service.d/override.conf
+++ b/software/distro/setup/base-os/tools/etc/systemd/system/docker.service.d/override.conf
@@ -1,3 +1,0 @@
-[Unit]
-# Don't wait for network-online.target, since that takes a long time
-After=docker.socket firewalld.service containerd.service time-set.target

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -12,10 +12,7 @@ sudo apt-get update -y
 sudo apt-get install -y vim byobu git
 
 # Install some tools for dealing with captive portals
-sudo apt-get install -y w3m
-# Note: we don't install browsh (which requires firefox-esr) because it adds ~200-300 MB of
-# dependencies in the base image. Users who need browsh should instead use the Docker image from
-# https://hub.docker.com/r/browsh/browsh
+sudo apt-get install -y w3m lynx
 
 # Install Docker
 sudo install -m 0755 -d /etc/apt/keyrings
@@ -26,14 +23,17 @@ echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y # get the list of packages from the docker repo
-VERSION_STRING=5:24.0.7-1~debian."$(. /etc/os-release && echo "$VERSION_ID")"~$(. /etc/os-release && echo "$VERSION_CODENAME")
+DOCKER_PLATFORM_STRING=debian."$(. /etc/os-release && echo "$VERSION_ID")"~$(. /etc/os-release && echo "$VERSION_CODENAME")
+DOCKER_VERSION_STRING=5:24.0.7-1~$DOCKER_PLATFORM_STRING
+CONTAINERD_VERSION_STRING=1.6.26-1
+COMPOSE_VERSION_STRING=2.21.0-1~$DOCKER_PLATFORM_STRING
 # The following command will fail with a post-install error if the system installed kernel updates
 # via apt upgrade but was not rebooted before installing docker-ce; however, even if this error
 # is reported, docker will work after reboot.
 # Refer to https://www.reddit.com/r/raspberry_pi/comments/zblky6/comment/iytpp4g/ for details.
 sudo apt-get install -y \
-  docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING \
-  containerd.io docker-compose-plugin
+  docker-ce=$DOCKER_VERSION_STRING docker-ce-cli=$DOCKER_VERSION_STRING \
+  containerd.io=$CONTAINERD_VERSION_STRING docker-compose-plugin=$COMPOSE_VERSION_STRING
 sudo apt-get remove -y docker-buildx-plugin
 
 # Install cockpit

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -26,7 +26,7 @@ echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y # get the list of packages from the docker repo
-VERSION_STRING=5:24.0.7-1~raspbian."$(. /etc/os-release && echo "VERSION_ID")"~$(. /etc/os-release && echo "VERSION_CODENAME")
+VERSION_STRING=5:24.0.7-1~raspbian."$(. /etc/os-release && echo "$VERSION_ID")"~$(. /etc/os-release && echo "$VERSION_CODENAME")
 # The following command will fail with a post-install error if the system installed kernel updates
 # via apt upgrade but was not rebooted before installing docker-ce; however, even if this error
 # is reported, docker will work after reboot.

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -26,7 +26,7 @@ echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y # get the list of packages from the docker repo
-VERSION_STRING=5:24.0.5-1~raspbian.11~bullseye # FIXME: make this work on both bullseye and bookworm
+VERSION_STRING=5:24.0.7-1~raspbian."$(. /etc/os-release && echo "VERSION_ID")"~$(. /etc/os-release && echo "VERSION_CODENAME")
 # The following command will fail with a post-install error if the system installed kernel updates
 # via apt upgrade but was not rebooted before installing docker-ce; however, even if this error
 # is reported, docker will work after reboot.

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -8,7 +8,6 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 # Install some tools for a nicer command-line experience over ssh
 # Note: we don't want to do an apt-get upgrade because then we'd have no way to ensure the same set
 # of package versions for existing packages if we run the script at different times.
-sudo apt-get update -y
 sudo apt-get install -y vim byobu git
 
 # Install some tools for dealing with captive portals

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -43,7 +43,8 @@ sudo apt-get remove -y docker-buildx-plugin
 
 # Install cockpit
 sudo apt-get update -y
-sudo apt-get install -y cockpit
+sudo apt-get install -y --no-install-recommends cockpit
+# TODO: after we switch to NetworkManager, add cockpit-networkmanager
 sudo mkdir -p /etc/cockpit/
 file="/etc/cockpit/cockpit.conf"
 sudo cp "$config_files_root$file" "$file"

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -18,22 +18,26 @@ sudo apt-get install -y w3m lynx
 sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
+DISTRO_VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID")"
+DISTRO_VERSION_CODENAME="$(. /etc/os-release && echo "$VERSION_CODENAME")"
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  "$DISTRO_VERSION_CODENAME" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y # get the list of packages from the docker repo
-DOCKER_PLATFORM_STRING=debian."$(. /etc/os-release && echo "$VERSION_ID")"~$(. /etc/os-release && echo "$VERSION_CODENAME")
+DOCKER_PLATFORM_STRING="debian.${DISTRO_VERSION_ID}~${DISTRO_VERSION_CODENAME}"
 DOCKER_VERSION_STRING=5:24.0.7-1~$DOCKER_PLATFORM_STRING
 CONTAINERD_VERSION_STRING=1.6.26-1
 COMPOSE_VERSION_STRING=2.21.0-1~$DOCKER_PLATFORM_STRING
-# The following command will fail with a post-install error if the system installed kernel updates
+# The following command may fail with a post-install error if the system installed kernel updates
 # via apt upgrade but was not rebooted before installing docker-ce; however, even if this error
 # is reported, docker will work after reboot.
 # Refer to https://www.reddit.com/r/raspberry_pi/comments/zblky6/comment/iytpp4g/ for details.
 sudo apt-get install -y \
-  docker-ce=$DOCKER_VERSION_STRING docker-ce-cli=$DOCKER_VERSION_STRING \
-  containerd.io=$CONTAINERD_VERSION_STRING docker-compose-plugin=$COMPOSE_VERSION_STRING
+  docker-ce=$DOCKER_VERSION_STRING \
+  docker-ce-cli=$DOCKER_VERSION_STRING \
+  containerd.io=$CONTAINERD_VERSION_STRING \
+  docker-compose-plugin=$COMPOSE_VERSION_STRING
 sudo apt-get remove -y docker-buildx-plugin
 
 # Install cockpit

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -19,14 +19,14 @@ sudo apt-get install -y w3m
 
 # Install Docker
 sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/raspbian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/raspbian \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y # get the list of packages from the docker repo
-VERSION_STRING=5:24.0.7-1~raspbian."$(. /etc/os-release && echo "$VERSION_ID")"~$(. /etc/os-release && echo "$VERSION_CODENAME")
+VERSION_STRING=5:24.0.7-1~debian."$(. /etc/os-release && echo "$VERSION_ID")"~$(. /etc/os-release && echo "$VERSION_CODENAME")
 # The following command will fail with a post-install error if the system installed kernel updates
 # via apt upgrade but was not rebooted before installing docker-ce; however, even if this error
 # is reported, docker will work after reboot.

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -42,10 +42,9 @@ sudo apt-get install -y \
 sudo apt-get remove -y docker-buildx-plugin
 
 # Allow Docker to start before the device is online on a network
-sudo mkdir -p "/etc/systemd/system/docker.service.d"
-file="/etc/systemd/system/docker.service.d/override.conf"
+file="/etc/systemd/system/docker.service"
 sudo cp "$config_files_root$file" "$file"
-sudo systemctl daemon-reload
+sudo systemctl enable docker.service
 
 # Install cockpit
 sudo apt-get update -y

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -14,17 +14,23 @@ sudo apt-get install -y vim byobu git
 sudo apt-get install -y w3m lynx
 
 # Install Docker
+if [ "$(uname -a)" -eq "aarch64" ]; then
+  DOCKER_REPOSITORY="debian"
+else
+  DOCKER_REPOSITORY="raspbian"
+fi
 sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+curl -fsSL "https://download.docker.com/linux/${DOCKER_REPOSITORY}/gpg" | \
+  sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 DISTRO_VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID")"
 DISTRO_VERSION_CODENAME="$(. /etc/os-release && echo "$VERSION_CODENAME")"
 echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${DOCKER_REPOSITORY} \
   "$DISTRO_VERSION_CODENAME" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y # get the list of packages from the docker repo
-DOCKER_PLATFORM_STRING="debian.${DISTRO_VERSION_ID}~${DISTRO_VERSION_CODENAME}"
+DOCKER_PLATFORM_STRING="${DOCKER_REPOSITORY}.${DISTRO_VERSION_ID}~${DISTRO_VERSION_CODENAME}"
 DOCKER_VERSION_STRING=5:24.0.7-1~$DOCKER_PLATFORM_STRING
 CONTAINERD_VERSION_STRING=1.6.26-1
 COMPOSE_VERSION_STRING=2.21.0-1~$DOCKER_PLATFORM_STRING

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -41,6 +41,11 @@ sudo apt-get install -y \
   docker-compose-plugin=$COMPOSE_VERSION_STRING
 sudo apt-get remove -y docker-buildx-plugin
 
+# Allow Docker to start before the device is online on a network
+file="/etc/systemd/system/docker.service.d/override.conf"
+sudo cp "$config_files_root$file" "$file"
+sudo systemctl daemon-reload
+
 # Install cockpit
 sudo apt-get update -y
 sudo apt-get install -y --no-install-recommends cockpit

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -7,7 +7,8 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Install some tools for a nicer command-line experience over ssh
 # Note: we don't want to do an apt-get upgrade because then we'd have no way to ensure the same set
-# of package versions for existing packages if we run the script at different times.
+# of package versions for existing packages if we run the script at different times. Also, it causes
+# some weirdness with the Docker installation (see note below in the "Install Docker" section).
 sudo apt-get install -y vim byobu git
 
 # Install some tools for dealing with captive portals

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -43,9 +43,6 @@ sudo apt-get remove -y docker-buildx-plugin
 # Install cockpit
 sudo apt-get update -y
 sudo apt-get install -y cockpit
-# We remove the NetworkManager integration because trying to use it will break the PlanktoScope's
-# current networking configuration.
-sudo apt-get remove -y cockpit-networkmanager
 sudo mkdir -p /etc/cockpit/
 file="/etc/cockpit/cockpit.conf"
 sudo cp "$config_files_root$file" "$file"

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -42,6 +42,7 @@ sudo apt-get install -y \
 sudo apt-get remove -y docker-buildx-plugin
 
 # Allow Docker to start before the device is online on a network
+sudo mkdir -p "/etc/systemd/system/docker.service.d"
 file="/etc/systemd/system/docker.service.d/override.conf"
 sudo cp "$config_files_root$file" "$file"
 sudo systemctl daemon-reload

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -14,23 +14,18 @@ sudo apt-get install -y vim byobu git
 sudo apt-get install -y w3m lynx
 
 # Install Docker
-if [ "$(uname -a)" -eq "aarch64" ]; then
-  DOCKER_REPOSITORY="debian"
-else
-  DOCKER_REPOSITORY="raspbian"
-fi
 sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL "https://download.docker.com/linux/${DOCKER_REPOSITORY}/gpg" | \
+curl -fsSL "https://download.docker.com/linux/debian/gpg" | \
   sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 DISTRO_VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID")"
 DISTRO_VERSION_CODENAME="$(. /etc/os-release && echo "$VERSION_CODENAME")"
 echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${DOCKER_REPOSITORY} \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
   "$DISTRO_VERSION_CODENAME" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update -y # get the list of packages from the docker repo
-DOCKER_PLATFORM_STRING="${DOCKER_REPOSITORY}.${DISTRO_VERSION_ID}~${DISTRO_VERSION_CODENAME}"
+DOCKER_PLATFORM_STRING="debian.${DISTRO_VERSION_ID}~${DISTRO_VERSION_CODENAME}"
 DOCKER_VERSION_STRING=5:24.0.7-1~$DOCKER_PLATFORM_STRING
 CONTAINERD_VERSION_STRING=1.6.26-1
 COMPOSE_VERSION_STRING=2.21.0-1~$DOCKER_PLATFORM_STRING

--- a/software/distro/setup/planktoscope-app-env/forklift/etc/systemd/system/planktoscope-org.forklift-apply.service
+++ b/software/distro/setup/planktoscope-app-env/forklift/etc/systemd/system/planktoscope-org.forklift-apply.service
@@ -2,6 +2,8 @@
 Description=Docker Compose applications specified by the local Forklift pallet
 Wants=docker.service
 After=docker.service
+# Delay the autohotspot until the Forklift pallet's network services are up:
+Before=autohotspot.service
 
 [Service]
 Type=oneshot

--- a/software/distro/setup/planktoscope-app-env/gps/install.sh
+++ b/software/distro/setup/planktoscope-app-env/gps/install.sh
@@ -14,7 +14,7 @@ sudo apt-get install -y gpsd pps-tools chrony
 # Note that this overrides a setting in the base-os/platform-hardware/config.sh script.
 # do_serial_cons is needed for Raspberry Pi OS 12 (bookworm) and above, while do_serial is needed
 # for Raspberry Pi OS (bullseye).
-sudo raspi-config do_serial_cons 1 || sudo raspi-config nonint do_serial 2
+sudo raspi-config nonint do_serial_cons 1 || sudo raspi-config nonint do_serial 2
 
 # Configure gpsd
 file="/etc/default/gpsd"

--- a/software/distro/setup/planktoscope-app-env/gps/install.sh
+++ b/software/distro/setup/planktoscope-app-env/gps/install.sh
@@ -12,9 +12,12 @@ sudo apt-get install -y gpsd pps-tools chrony
 # The following command enables the serial port but disables the login shell over the serial port.
 # We use this because the serial port is reserved for a GPS device.
 # Note that this overrides a setting in the base-os/platform-hardware/config.sh script.
-# do_serial_cons is needed for Raspberry Pi OS 12 (bookworm) and above, while do_serial is needed
-# for Raspberry Pi OS (bullseye).
-sudo raspi-config nonint do_serial_cons 1 || sudo raspi-config nonint do_serial 2
+DISTRO_VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID")"
+if [ $DISTRO_VERSION_ID -ge 12 ]; then # Support Raspberry Pi OS 12 (bookworm)
+  sudo raspi-config nonint do_serial_cons 1
+else # Support Raspberry Pi OS 11 (bullseye)
+  sudo raspi-config nonint do_serial 2
+fi
 
 # Configure gpsd
 file="/etc/default/gpsd"

--- a/software/distro/setup/planktoscope-app-env/gps/install.sh
+++ b/software/distro/setup/planktoscope-app-env/gps/install.sh
@@ -6,7 +6,6 @@
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Install dependencies
-sudo apt-get update -y
 sudo apt-get install -y gpsd pps-tools chrony
 
 # The following command enables the serial port but disables the login shell over the serial port.

--- a/software/distro/setup/planktoscope-app-env/gps/install.sh
+++ b/software/distro/setup/planktoscope-app-env/gps/install.sh
@@ -12,7 +12,9 @@ sudo apt-get install -y gpsd pps-tools chrony
 # The following command enables the serial port but disables the login shell over the serial port.
 # We use this because the serial port is reserved for a GPS device.
 # Note that this overrides a setting in the base-os/platform-hardware/config.sh script.
-sudo raspi-config nonint do_serial 2
+# do_serial_cons is needed for Raspberry Pi OS 12 (bookworm) and above, while do_serial is needed
+# for Raspberry Pi OS (bullseye).
+sudo raspi-config do_serial_cons 1 || sudo raspi-config nonint do_serial 2
 
 # Configure gpsd
 file="/etc/default/gpsd"

--- a/software/distro/setup/planktoscope-app-env/networking/config.sh
+++ b/software/distro/setup/planktoscope-app-env/networking/config.sh
@@ -5,7 +5,6 @@
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Install dependencies
-sudo apt-get update -y
 sudo apt-get install -y avahi-utils
 
 # Set the default hostname, which will be updated with the machine name on boot

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -28,7 +28,7 @@ $POETRY_VENV/bin/pip install cryptography==41.0.5
 $POETRY_VENV/bin/pip install poetry==1.6.1
 
 # Download device-backend monorepo
-backend_version="v2023.9.0" # this should be either a version tag, branch name, or commit hash
+backend_version="feature/rpios-bookworm" # this should be either a version tag, branch name, or commit hash
 git clone https://github.com/PlanktoScope/device-backend $HOME/device-backend --no-checkout --filter=blob:none
 git -C $HOME/device-backend checkout --quiet $backend_version
 

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -25,7 +25,7 @@ mkdir -p $POETRY_VENV
 python3 -m venv $POETRY_VENV
 $POETRY_VENV/bin/pip install --upgrade pip==23.3.2 setuptools==68.2.2
 $POETRY_VENV/bin/pip install cryptography==41.0.5
-$POETRY_VENV/bin/pip install poetry==1.6.1
+$POETRY_VENV/bin/pip install poetry==1.7.1
 
 # Download device-backend monorepo
 backend_version="feature/rpios-bookworm" # this should be either a version tag, branch name, or commit hash

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -23,13 +23,9 @@ sudo apt-get install -y git python3-pip python3-venv
 POETRY_VENV=$HOME/.local/share/pypoetry/venv
 mkdir -p $POETRY_VENV
 python3 -m venv $POETRY_VENV
-$POETRY_VENV/bin/pip install --upgrade pip==23.3.1 setuptools==68.2.2
+$POETRY_VENV/bin/pip install --upgrade pip==23.3.2 setuptools==68.2.2
 $POETRY_VENV/bin/pip install cryptography==41.0.5
 $POETRY_VENV/bin/pip install poetry==1.6.1
-
-# Install pipx (not required, but useful)
-python3 -m pip install --user pipx==1.2.0
-python3 -m pipx ensurepath
 
 # Download device-backend monorepo
 backend_version="v2023.9.0" # this should be either a version tag, branch name, or commit hash

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -58,7 +58,7 @@ cp -r "$repo_root/$directory" $HOME/PlanktoScope/$directory
 # Set up the data processing segmenter
 # FIXME: if we're not using libhdf5, libopenjp2-7, libopenexr25, libavcodec58, libavformat58, and
 # libswscale5, can we avoid the need to install them?
-sudo apt-get install -y libatlas3-base \
+sudo apt-get install -y libopenblas0 libatlas3-base \
   libhdf5-103-1 libopenjp2-7 libopenexr25 libavcodec58 libavformat58 libswscale5
 $POETRY_VENV/bin/poetry --directory $HOME/device-backend/processing/segmenter install --no-root --compile
 file="/etc/systemd/system/planktoscope-org.device-backend.processing.segmenter.service"

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -28,7 +28,7 @@ $POETRY_VENV/bin/pip install cryptography==41.0.5
 $POETRY_VENV/bin/pip install poetry==1.7.1
 
 # Download device-backend monorepo
-backend_version="feature/rpios-bookworm" # this should be either a version tag, branch name, or commit hash
+backend_version="2872828" # this should be either a version tag, branch name, or commit hash
 git clone https://github.com/PlanktoScope/device-backend $HOME/device-backend --no-checkout --filter=blob:none
 git -C $HOME/device-backend checkout --quiet $backend_version
 

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -57,10 +57,7 @@ cp -r "$repo_root/$directory" $HOME/PlanktoScope/$directory
 
 # Set up the data processing segmenter
 # FIXME: if we're not using libhdf5, libopenjp2-7, libopenexr25, libavcodec58, libavformat58, and
-# libswscale5, can we avoid the need to install them? Right now they're required because the Python
-# backend is doing an `import * from cv2`, which is wasteful and also pollutes the namespace - if we
-# only import the required subpackages from cv2, maybe we can avoid the need to install unnecessary
-# dependencies via apt-get?
+# libswscale5, can we avoid the need to install them?
 sudo apt-get install -y libatlas3-base \
   libhdf5-103-1 libopenjp2-7 libopenexr25 libavcodec58 libavformat58 libswscale5
 $POETRY_VENV/bin/poetry --directory $HOME/device-backend/processing/segmenter install --no-root --compile

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -34,7 +34,7 @@ git -C $HOME/device-backend checkout --quiet $backend_version
 
 # Set up the hardware controllers
 sudo apt-get install -y i2c-tools
-$POETRY_VENV/bin/poetry --directory $HOME/device-backend/control install
+$POETRY_VENV/bin/poetry --directory $HOME/device-backend/control install --no-root --compile
 file="/etc/systemd/system/planktoscope-org.device-backend.controller-adafruithat.service"
 sudo cp "$config_files_root$file" "$file"
 # or for the PlanktoScope HAT
@@ -63,7 +63,7 @@ cp -r "$repo_root/$directory" $HOME/PlanktoScope/$directory
 # dependencies via apt-get?
 sudo apt-get install -y libatlas3-base \
   libhdf5-103-1 libopenjp2-7 libopenexr25 libavcodec58 libavformat58 libswscale5
-$POETRY_VENV/bin/poetry --directory $HOME/device-backend/processing/segmenter install
+$POETRY_VENV/bin/poetry --directory $HOME/device-backend/processing/segmenter install --no-root --compile
 file="/etc/systemd/system/planktoscope-org.device-backend.processing.segmenter.service"
 sudo cp "$config_files_root$file" "$file"
 sudo systemctl enable planktoscope-org.device-backend.processing.segmenter.service

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -20,6 +20,7 @@ sudo apt-get install -y git python3-pip python3-venv
 # installation to ensure that a wheel is available from piwheels for the cryptography dependency.
 # We have had problems in the past with a version of that dependency not being available from
 # piwheels.
+# TODO: now that we're migrating to aarch64, use a more modern version of poetry
 POETRY_VENV=$HOME/.local/share/pypoetry/venv
 mkdir -p $POETRY_VENV
 python3 -m venv $POETRY_VENV
@@ -28,7 +29,7 @@ $POETRY_VENV/bin/pip install cryptography==41.0.5
 $POETRY_VENV/bin/pip install poetry==1.6.1
 
 # Download device-backend monorepo
-backend_version="v2023.9.0" # this should be either a version tag, branch name, or commit hash
+backend_version="feature/rpios-bookworm" # this should be either a version tag, branch name, or commit hash
 git clone https://github.com/PlanktoScope/device-backend $HOME/device-backend --no-checkout --filter=blob:none
 git -C $HOME/device-backend checkout --quiet $backend_version
 

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -33,7 +33,7 @@ git clone https://github.com/PlanktoScope/device-backend $HOME/device-backend --
 git -C $HOME/device-backend checkout --quiet $backend_version
 
 # Set up the hardware controllers
-sudo apt-get install -y i2c-tools
+sudo apt-get install -y --no-install-recommends i2c-tools
 $POETRY_VENV/bin/poetry --directory $HOME/device-backend/control install --no-root --compile
 file="/etc/systemd/system/planktoscope-org.device-backend.controller-adafruithat.service"
 sudo cp "$config_files_root$file" "$file"

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -19,7 +19,7 @@ sudo apt-get install -y git python3-pip python3-venv
 # installation to ensure that a wheel is available from piwheels for the cryptography dependency.
 # We have had problems in the past with a version of that dependency not being available from
 # piwheels.
-# TODO: now that we're migrating to aarch64, use a more modern version of poetry
+# TODO: for aarch64, use a more modern version of poetry
 POETRY_VENV=$HOME/.local/share/pypoetry/venv
 mkdir -p $POETRY_VENV
 python3 -m venv $POETRY_VENV
@@ -28,7 +28,7 @@ $POETRY_VENV/bin/pip install cryptography==41.0.5
 $POETRY_VENV/bin/pip install poetry==1.6.1
 
 # Download device-backend monorepo
-backend_version="feature/rpios-bookworm" # this should be either a version tag, branch name, or commit hash
+backend_version="v2023.9.0" # this should be either a version tag, branch name, or commit hash
 git clone https://github.com/PlanktoScope/device-backend $HOME/device-backend --no-checkout --filter=blob:none
 git -C $HOME/device-backend checkout --quiet $backend_version
 

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -11,7 +11,6 @@ repo_root=$(dirname $(dirname $(dirname $distro_setup_files_root)))
 hardware_type="$1" # should be either adafruithat or pscopehat
 
 ## Install basic Python tooling
-sudo apt-get update -y
 sudo apt-get install -y git python3-pip python3-venv
 
 # Install Poetry

--- a/software/distro/setup/setup.sh
+++ b/software/distro/setup/setup.sh
@@ -41,6 +41,8 @@ function panic {
 
 echo -e "${script_fmt}Setting up full operating system...${reset_fmt}"
 
+sudo apt-get update -y
+
 description="set up base operating system"
 report_starting "$description"
 if $setup_scripts_root/base-os/setup.sh ; then


### PR DESCRIPTION
This PR adds partial support in the distro setup scripts for the 32-bit and 64-bit versions of Raspberry Pi OS 12 (bookworm), while attempting to maintain backwards-compatibility with Raspberry Pi OS 11 (bullseye). Specifically, this PR fixes some issues when trying to run the distro setup scripts on bullseye.

This PR also:
- fixes a systemd warning related to dependencies between `autohotspot.service` and `enable-interface-forwarding.service`, and enables `autohotspot.service` to start sooner (even before all network services are brought up by forklift)
- greatly improves boot times by forking `dhcpcd.service` to the background even before it has acquired IP addresses from networks
- removes some unnecessary dependencies (esp. of cockpit), reducing SD card image size from 1.6 GB to 1.3 GB

Testing checklist:
- [x] Do the scripts lead to a working SD card image on 32-bit bookworm? If not, what errors occur?
- [x] Do the scripts lead to a working SD card image on 64-bit bookworm? If not, what errors occur?
- [x] Do the scripts still lead to a working SD card image on bullseye 32-bit?
- [x] Is the new behavior of autohotspot reasonable?
- [x] Does the changelog reflect all changes made in this PR?

Wrap-up checklist:
- Merge https://github.com/PlanktoScope/device-backend/pull/15
- Change the python backend setup script to use the merged commit on device-backend's main branch