### PR TITLE
Try to fix GitHub Actions permissions for docker/build-and-push action

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -30,6 +30,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -105,6 +108,9 @@ jobs:
 
   build-minimal:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR attempts to resolve the GitHub Actions errors in the documentation-build workflow for the following PRs:
- #337 
- #336 
- #335 
- #334 
- #333 
- #332 
- #331 
- #330 
- #329 
- #328 

The error occurs in the "build and push" step:
```
[...]

#18 [auth] planktoscope/project-docs:pull,push token for ghcr.io
#18 DONE 0.0s

#17 exporting to image
#17 pushing layers 0.2s done
#17 ERROR: failed to push ghcr.io/planktoscope/project-docs:pr-328: unexpected status from POST request to https://ghcr.io/v2/planktoscope/project-docs/blobs/uploads/: 403 Forbidden
------
 > exporting to image:
------
ERROR: failed to solve: failed to push ghcr.io/planktoscope/project-docs:pr-328: unexpected status from POST request to https://ghcr.io/v2/planktoscope/project-docs/blobs/uploads/: 403 Forbidden
Error: buildx failed with: ERROR: failed to solve: failed to push ghcr.io/planktoscope/project-docs:pr-328: unexpected status from POST request to https://ghcr.io/v2/planktoscope/project-docs/blobs/uploads/: 403 Forbidden
```

According to https://github.com/docker/build-push-action/issues/687#issuecomment-1651816012, maybe we just need to explicitly set the permissions for the jobs. This PR attempts to do that.