### PR TITLE
Fix issue with required status checks not running

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -15,11 +15,6 @@ on:
     tags:
       - 'documentation/v*'
   pull_request:
-    paths:
-      - 'documentation/**'
-      - 'hardware/**'
-      - 'software/CHANGELOG.md'
-      - '.github/workflows/documentation-build.yml'
   merge_group:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This PR fixes an issue with the GitHub Actions jobs in the `documentation-build.yml` workflow not running on PRs where documentation-related files had not been changed despite those jobs being required as status checks for merging onto master (e.g. as in #319). The fix recommended by https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks is to remove path filtering and branch filtering. This PR removes path filters for pull request triggers, but keeps branch filters on pushes to branches - hopefully we can keep the latter.