### PR TITLE
Allow running Docker commands without sudo

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.MM.patch` scheme
+and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme
 for all releases after `v2.3.0`.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
@@ -16,6 +16,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 ### Changed
 
 - (System: security) `ufw` has been replaced with `firewalld`. However, firewalld has not yet been properly configured.
+- (System: administration) Docker commands can now be run without `sudo`.
 
 ### Removed
 

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -46,6 +46,9 @@ file="/etc/systemd/system/docker.service"
 sudo cp "$config_files_root$file" "$file"
 sudo systemctl enable docker.service
 
+# Allow running Docker commands without sudo
+sudo usermod -aG docker $USER
+
 # Install cockpit
 sudo apt-get update -y
 sudo apt-get install -y --no-install-recommends cockpit

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -48,6 +48,7 @@ sudo systemctl enable docker.service
 
 # Allow running Docker commands without sudo
 sudo usermod -aG docker $USER
+newgrp docker
 
 # Install cockpit
 sudo apt-get update -y

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -48,7 +48,6 @@ sudo systemctl enable docker.service
 
 # Allow running Docker commands without sudo
 sudo usermod -aG docker $USER
-newgrp docker
 
 # Install cockpit
 sudo apt-get update -y

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -9,12 +9,15 @@ pallet_version="v2023.9.0"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C $HOME/.local/bin -xz forklift
+forklift="$HOME/.local/bin/forklift"
 workspace="$HOME/.forklift"
-forklift() {
-  $HOME/.local/bin/forklift "$@"
-}
-forklift --workspace $workspace plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
-forklift --workspace $workspace plt cache-repo
+$forklift --workspace $workspace plt rm
+$forklift --workspace $workspace plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
+$forklift --workspace $workspace plt cache-repo
+
+# Note: the below commands must run with sudo even though the pi user has been added to the docker
+# usergroup, because that change only works after starting a new login shell; and `newgrp docker`
+# doesn't work either.
 # Note: cache-img downloads images even for disabled package deployments. We skip it to save disk
 # space (because the node-red container image used by a test package is >100 MB, even though we
 # don't need it yet), we don't yet have any packages in the pallet which someone might want to
@@ -24,8 +27,8 @@ forklift --workspace $workspace plt cache-repo
 # we can use the command here to only cache enabled package deployments. We may get a slight speedup
 # if we can download all the images in parallel, without having to start the services all in
 # parallel (which would add lots of runtime nondeterminism to the system)
-# forklift --workspace $workspace plt cache-img
-forklift --workspace $workspace plt apply
+# sudo -E $forklift --workspace $workspace plt cache-img
+sudo -E $forklift --workspace $workspace plt apply
 # Note: we apply the pallet immediately so that the first boot of the image won't be excessively
 # slow (due to Docker Compose needing to create all the services from scratch rather than simply
 # starting them).

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -9,11 +9,14 @@ pallet_version="v2023.9.0"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C $HOME/.local/bin -xz forklift
-forklift="$HOME/.local/bin/forklift"
 workspace="$HOME/.forklift"
-$forklift --workspace $workspace plt rm
-$forklift --workspace $workspace plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
-$forklift --workspace $workspace plt cache-repo
+forklift="$HOME/.local/bin/forklift --workspace $workspace"
+if [ -d "$workspace" ]; then
+  $forklift plt rm
+fi
+$forklift plt rm
+$forklift plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
+$forklift plt cache-repo
 
 # Note: the below commands must run with sudo even though the pi user has been added to the docker
 # usergroup, because that change only works after starting a new login shell; and `newgrp docker`
@@ -27,8 +30,8 @@ $forklift --workspace $workspace plt cache-repo
 # we can use the command here to only cache enabled package deployments. We may get a slight speedup
 # if we can download all the images in parallel, without having to start the services all in
 # parallel (which would add lots of runtime nondeterminism to the system)
-# sudo -E $forklift --workspace $workspace plt cache-img
-sudo -E $forklift --workspace $workspace plt apply
+# sudo -E $forklift plt cache-img
+sudo -E $forklift plt apply
 # Note: we apply the pallet immediately so that the first boot of the image won't be excessively
 # slow (due to Docker Compose needing to create all the services from scratch rather than simply
 # starting them).

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -9,10 +9,10 @@ pallet_version="v2023.9.0"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C $HOME/.local/bin -xz forklift
-forklift="$HOME/.local/bin/forklift"
+alias forklift="$HOME/.local/bin/forklift"
 workspace="$HOME/.forklift"
-$forklift --workspace $workspace plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
-$forklift --workspace $workspace plt cache-repo
+forklift --workspace $workspace plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
+forklift --workspace $workspace plt cache-repo
 # Note: cache-img downloads images even for disabled package deployments. We skip it to save disk
 # space (because the node-red container image used by a test package is >100 MB, even though we
 # don't need it yet), we don't yet have any packages in the pallet which someone might want to
@@ -22,8 +22,8 @@ $forklift --workspace $workspace plt cache-repo
 # we can use the command here to only cache enabled package deployments. We may get a slight speedup
 # if we can download all the images in parallel, without having to start the services all in
 # parallel (which would add lots of runtime nondeterminism to the system)
-# sudo -E $forklift --workspace $workspace plt cache-img
-sudo -E $forklift --workspace $workspace plt apply
+# forklift --workspace $workspace plt cache-img
+forklift --workspace $workspace plt apply
 # Note: we apply the pallet immediately so that the first boot of the image won't be excessively
 # slow (due to Docker Compose needing to create all the services from scratch rather than simply
 # starting them).

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -9,8 +9,10 @@ pallet_version="v2023.9.0"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C $HOME/.local/bin -xz forklift
-alias forklift="$HOME/.local/bin/forklift"
 workspace="$HOME/.forklift"
+forklift() {
+  $HOME/.local/bin/forklift "$@"
+}
 forklift --workspace $workspace plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
 forklift --workspace $workspace plt cache-repo
 # Note: cache-img downloads images even for disabled package deployments. We skip it to save disk


### PR DESCRIPTION
This PR adds the `pi` user to the `docker` usergroup so that the `pi` user can run Docker and Forklift commands without sudo.