### PR TITLE
Bump pallet-standard to add Dozzle

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -12,6 +12,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 ### Added
 
 - (System: networking) Added `lynx` as an alternative terminal web browser to `w3m` for trying to work through captive portals on the Cockpit terminal.
+- (System: administration) Added Dozzle as a viewer for Docker container logs.
 
 ### Changed
 

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -5,7 +5,7 @@
 
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 forklift_version="0.4.0"
-pallet_version="v2023.9.0"
+pallet_version="679447f"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C $HOME/.local/bin -xz forklift


### PR DESCRIPTION
This PR adds [Dozzle](https://dozzle.dev/) as a Docker container log viewer. This allows us to link to a page to view the logs of any specified Docker Compose service (which was not possible with Portainer). This is needed for #326, #190, etc.