### PR TITLE
Run `forklift plt apply` with parallelization

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -33,7 +33,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ### Fixed
 
-- (System) Boot time has been made faster by approximately 30 seconds.
+- (System) Boot time has been made faster by approximately 1 minute.
 - (System) The base OS setup scripts now run without errors on both the 32-bit and 64-bit versions of Raspberry Pi OS 12 (bookworm). However, setup of the PlanktoScope applications still fails with errors on bookworm and on 64-bit versions of the Raspberry Pi OS.
 - (System) Functionality for automatically updating the `/etc/hosts` file and the hostname based on the machine name has now been split into two separate system services, `planktoscope-org.update-hosts-machine-name.service` and `planktoscope-org.update-hostname-machine-name.service`.
 

--- a/software/distro/setup/planktoscope-app-env/forklift/etc/systemd/system/planktoscope-org.forklift-apply.service
+++ b/software/distro/setup/planktoscope-app-env/forklift/etc/systemd/system/planktoscope-org.forklift-apply.service
@@ -7,7 +7,7 @@ Before=autohotspot.service
 
 [Service]
 Type=oneshot
-ExecStart=/home/pi/.local/bin/forklift --workspace /home/pi/.forklift plt apply
+ExecStart=/home/pi/.local/bin/forklift --workspace /home/pi plt apply --parallel || /home/pi/.local/bin/forklift --workspace /home/pi plt apply
 
 [Install]
 WantedBy=multi-user.target

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -4,8 +4,8 @@
 # distribution
 
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
-forklift_version="0.4.0"
-pallet_version="72ecce01"
+forklift_version="0.5.0"
+pallet_version="c84c827"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C $HOME/.local/bin -xz forklift
@@ -20,24 +20,13 @@ $forklift plt cache-repo
 # Note: the below commands must run with sudo even though the pi user has been added to the docker
 # usergroup, because that change only works after starting a new login shell; and `newgrp docker`
 # doesn't work either.
-# Note: cache-img downloads images even for disabled package deployments. We skip it to save disk
-# space (because the node-red container image used by a test package is >100 MB, even though we
-# don't need it yet), we don't yet have any packages in the pallet which someone might want to
-# enable, and because we're running plt apply anyways - that command will download images as needed
-# for each (enabled) package deployment. We will want to have a cache-img flag which controls
-# whether only enabled package deployments are cached or all package deployments are cached, so that
-# we can use the command here to only cache enabled package deployments. We may get a slight speedup
-# if we can download all the images in parallel, without having to start the services all in
-# parallel (which would add lots of runtime nondeterminism to the system)
-# sudo -E $forklift plt cache-img
-sudo -E $forklift plt apply
+sudo -E $forklift plt cache-img --parallel # to save disk space, don't cache images used by disabled package deployments
 # Note: we apply the pallet immediately so that the first boot of the image won't be excessively
 # slow (due to Docker Compose needing to create all the services from scratch rather than simply
 # starting them).
+sudo -E $forklift plt apply --parallel
 
-# Apply pallet after Docker is initialized, because the system needs to be restarted after Docker is
-# installed before the Docker service will be able to start successfully.
-# Refer to https://www.reddit.com/r/raspberry_pi/comments/zblky6/comment/iytpp4g/ for details.
+# The pallet must be applied during each startup because we're using Docker Compose, not Swarm Mode.
 file="/etc/systemd/system/planktoscope-org.forklift-apply.service"
 sudo cp "$config_files_root$file" "$file"
 sudo systemctl enable planktoscope-org.forklift-apply.service

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -11,20 +11,13 @@ curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_v
   | tar -C $HOME/.local/bin -xz forklift
 workspace="$HOME"
 forklift="$HOME/.local/bin/forklift --workspace $workspace"
-if [ -d "$workspace" ]; then
-  $forklift plt rm
-fi
-$forklift plt clone github.com/PlanktoScope/pallet-standard@$pallet_version
+$forklift plt clone --force github.com/PlanktoScope/pallet-standard@$pallet_version
 $forklift plt cache-repo
 
-# Note: the below commands must run with sudo even though the pi user has been added to the docker
+# Note: this command must run with sudo even though the pi user has been added to the docker
 # usergroup, because that change only works after starting a new login shell; and `newgrp docker`
 # doesn't work either.
-sudo -E $forklift plt cache-img --parallel # to save disk space, don't cache images used by disabled package deployments
-# Note: we apply the pallet immediately so that the first boot of the image won't be excessively
-# slow (due to Docker Compose needing to create all the services from scratch rather than simply
-# starting them).
-#sudo -E $forklift plt apply --parallel
+sudo -E $forklift plt cache-img --parallel # to save disk space, we don't cache images used by disabled package deployments
 
 # The pallet must be applied during each startup because we're using Docker Compose, not Swarm Mode.
 file="/etc/systemd/system/planktoscope-org.forklift-apply.service"

--- a/software/distro/setup/planktoscope-app-env/forklift/install.sh
+++ b/software/distro/setup/planktoscope-app-env/forklift/install.sh
@@ -9,7 +9,7 @@ pallet_version="c84c827"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | tar -C $HOME/.local/bin -xz forklift
-workspace="$HOME/.forklift"
+workspace="$HOME"
 forklift="$HOME/.local/bin/forklift --workspace $workspace"
 if [ -d "$workspace" ]; then
   $forklift plt rm
@@ -24,7 +24,7 @@ sudo -E $forklift plt cache-img --parallel # to save disk space, don't cache ima
 # Note: we apply the pallet immediately so that the first boot of the image won't be excessively
 # slow (due to Docker Compose needing to create all the services from scratch rather than simply
 # starting them).
-sudo -E $forklift plt apply --parallel
+#sudo -E $forklift plt apply --parallel
 
 # The pallet must be applied during each startup because we're using Docker Compose, not Swarm Mode.
 file="/etc/systemd/system/planktoscope-org.forklift-apply.service"


### PR DESCRIPTION
This PR fixes #219 by incorporating improvements made in https://github.com/PlanktoScope/forklift/pull/111 and https://github.com/PlanktoScope/pallet-standard/pull/4 . As described in https://github.com/PlanktoScope/forklift/pull/111, this reduces boot time (and the time until the Node-RED dashboard becomes ready) by a further ~25 seconds.