### PR TITLE
Don't suppress wget errors in the docs's non-standard install commands

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Build documentation website
       - name: Install poetry
-        run: pipx install poetry==1.5.0
+        run: pipx install poetry==1.7.1
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -111,12 +111,12 @@ jobs:
 
       # Build minimal documentation website (without hardware setup guides, to save space)
       - name: Install poetry
-        run: pipx install poetry==1.5.0
+        run: pipx install poetry==1.7.1
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'poetry'
           cache-dependency-path: |
             documentation/poetry.lock

--- a/.github/workflows/documentation-deploy-beta.yml
+++ b/.github/workflows/documentation-deploy-beta.yml
@@ -31,12 +31,12 @@ jobs:
           sudo apt-get -y install pngquant
 
       - name: Install poetry
-        run: pipx install poetry==1.5.0
+        run: pipx install poetry==1.7.1
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'poetry'
           cache-dependency-path: |
             documentation/poetry.lock

--- a/.github/workflows/documentation-deploy-edge.yml
+++ b/.github/workflows/documentation-deploy-edge.yml
@@ -44,12 +44,12 @@ jobs:
           sudo apt-get -y install pngquant
 
       - name: Install poetry
-        run: pipx install poetry==1.5.0
+        run: pipx install poetry==1.7.1
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'poetry'
           cache-dependency-path: |
             documentation/poetry.lock

--- a/.github/workflows/documentation-deploy-stable.yml
+++ b/.github/workflows/documentation-deploy-stable.yml
@@ -31,12 +31,12 @@ jobs:
           sudo apt-get -y install pngquant
 
       - name: Install poetry
-        run: pipx install poetry==1.5.0
+        run: pipx install poetry==1.7.1
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'poetry'
           cache-dependency-path: |
             documentation/poetry.lock

--- a/documentation/docs/setup/software/nonstandard-install.md
+++ b/documentation/docs/setup/software/nonstandard-install.md
@@ -65,7 +65,7 @@ Log in to your Raspberry Pi and (if you installed a version of Raspberry Pi OS w
 === "latest beta"
 
     ```
-    wget -qO - https://install.planktoscope.community/distro.sh \
+    wget -O - https://install.planktoscope.community/distro.sh \
       | sh -s -- -v software/beta -H pscopehat
     ```
     
@@ -74,7 +74,7 @@ Log in to your Raspberry Pi and (if you installed a version of Raspberry Pi OS w
 === "latest stable"
 
     ```
-    wget -qO - https://install.planktoscope.community/distro.sh \
+    wget -O - https://install.planktoscope.community/distro.sh \
       | sh -s -- -v software/stable -H pscopehat
     ```
     
@@ -83,7 +83,7 @@ Log in to your Raspberry Pi and (if you installed a version of Raspberry Pi OS w
 === "development"
 
     ```
-    wget -qO - https://install.planktoscope.community/distro.sh \
+    wget -O - https://install.planktoscope.community/distro.sh \
       | sh -s -- -v master -H pscopehat
     ```
     
@@ -92,14 +92,14 @@ Log in to your Raspberry Pi and (if you installed a version of Raspberry Pi OS w
 Instead of installing the latest beta, stable, or development version, you can also install a specific tagged release or pre-release of the PlanktoScope software. For example, to install the v2023.9.0-beta.1 prerelease of the PlanktoScope software, you would run the following command:
 
 ```
-wget -qO - https://install.planktoscope.community/distro.sh \
+wget -O - https://install.planktoscope.community/distro.sh \
   | sh -s -- -t tag -v v2023.9.0-beta.1 -H pscopehat
 ```
 
 Note that you can also choose to install the PlanktoScope software from some other repository on GitHub instead of github.com/PlanktoScope/PlanktoScope, by using the `-r` command-line option; for more information, you can get usage instructions by running the following command:
 
 ```
-wget -qO - https://install.planktoscope.community/distro.sh \
+wget -O - https://install.planktoscope.community/distro.sh \
   | sh -s -- --help
 ```
 


### PR DESCRIPTION
This PR changes the software documentation's [non-standard installation guide](https://docs.planktoscope.community/setup/software/nonstandard-install/#run-the-installation-script) so that the wget command doesn't suppress error messages. This way, if the download of the installation script fails (e.g. due to lack of internet access), the user will see an error message to that effect, rather than having the command finish silently without any error indications.