### PR TITLE
Replace slider with text input to set pump volume

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -25,6 +25,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - (System: security) `ufw` has been replaced with `firewalld`. However, firewalld has not yet been properly configured.
 - (System: administration) Docker commands can now be run without `sudo`.
 - (Application: GUI) The "System Monitoring" page now uses a Grafana dashboard to display metrics.
+- (Application: GUI) The "Fluidic Acquisition" page now uses a numeric text input instead of a slider for adjusting the "Pumped volume" setting, to make it easier to change the setting to a different exact value.
 - (System) The PlanktoScope's machine name is now saved to `/var/lib/planktoscope/machine-name` instead of `/home/pi/.local/etc/machine-name`, and it's now saved without a trailing newline.
 
 ### Removed

--- a/software/node-red-dashboard/flows/adafruithat.json
+++ b/software/node-red-dashboard/flows/adafruithat.json
@@ -5807,34 +5807,6 @@
         ]
     },
     {
-        "id": "df1ea904.cd261",
-        "type": "ui_slider",
-        "z": "baa1e3d9.cb29d",
-        "name": "imaging_pump_volume",
-        "label": "Pumped volume (mL)",
-        "tooltip": "inbetween frames",
-        "group": "4322c187.e73e5",
-        "order": 3,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "outs": "end",
-        "topic": "imaging_pump_volume",
-        "topicType": "str",
-        "min": "0.001",
-        "max": "0.5",
-        "step": "0.001",
-        "className": "",
-        "x": 630,
-        "y": 320,
-        "wires": [
-            [
-                "fb887036.12429",
-                "67091ac0.8f9f6c"
-            ]
-        ]
-    },
-    {
         "id": "a4abb1ae.2ae418",
         "type": "subflow:1c24ad9c.bebec2",
         "z": "baa1e3d9.cb29d",
@@ -5880,7 +5852,7 @@
         "y": 320,
         "wires": [
             [
-                "df1ea904.cd261"
+                "e1acc6c599033114"
             ]
         ]
     },
@@ -5937,6 +5909,33 @@
         ],
         "outputLabels": [
             "interface"
+        ]
+    },
+    {
+        "id": "e1acc6c599033114",
+        "type": "ui_text_input",
+        "z": "baa1e3d9.cb29d",
+        "name": "imaging_pump_volume",
+        "label": "Pumped volume (mL)",
+        "tooltip": "between frames",
+        "group": "4322c187.e73e5",
+        "order": 3,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "mode": "text",
+        "delay": 300,
+        "topic": "imaging_pump_volume",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "str",
+        "x": 630,
+        "y": 320,
+        "wires": [
+            [
+                "fb887036.12429",
+                "67091ac0.8f9f6c"
+            ]
         ]
     },
     {

--- a/software/node-red-dashboard/flows/pscopehat.json
+++ b/software/node-red-dashboard/flows/pscopehat.json
@@ -5848,34 +5848,6 @@
         ]
     },
     {
-        "id": "df1ea904.cd261",
-        "type": "ui_slider",
-        "z": "baa1e3d9.cb29d",
-        "name": "imaging_pump_volume",
-        "label": "Pumped volume (mL)",
-        "tooltip": "inbetween frames",
-        "group": "4322c187.e73e5",
-        "order": 3,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "outs": "end",
-        "topic": "imaging_pump_volume",
-        "topicType": "str",
-        "min": "0.001",
-        "max": "0.5",
-        "step": "0.001",
-        "className": "",
-        "x": 630,
-        "y": 260,
-        "wires": [
-            [
-                "fb887036.12429",
-                "67091ac0.8f9f6c"
-            ]
-        ]
-    },
-    {
         "id": "a4abb1ae.2ae418",
         "type": "subflow:1c24ad9c.bebec2",
         "z": "baa1e3d9.cb29d",
@@ -5921,7 +5893,7 @@
         "y": 260,
         "wires": [
             [
-                "df1ea904.cd261"
+                "0df8d1d86af6455a"
             ]
         ]
     },
@@ -5979,6 +5951,33 @@
         ],
         "outputLabels": [
             "interface"
+        ]
+    },
+    {
+        "id": "0df8d1d86af6455a",
+        "type": "ui_text_input",
+        "z": "baa1e3d9.cb29d",
+        "name": "imaging_pump_volume",
+        "label": "Pumped volume (mL)",
+        "tooltip": "between frames",
+        "group": "4322c187.e73e5",
+        "order": 3,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "mode": "number",
+        "delay": 300,
+        "topic": "imaging_pump_volume",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "str",
+        "x": 630,
+        "y": 260,
+        "wires": [
+            [
+                "fb887036.12429",
+                "67091ac0.8f9f6c"
+            ]
         ]
     },
     {


### PR DESCRIPTION
This PR resolves #355 by replacing the "Fluidic Acquisition" page's "Pumped volume" input slider with a numeric text input field. Here's what it looks like now:
![image](https://github.com/PlanktoScope/PlanktoScope/assets/180370/18795a96-43b4-440b-807f-d27a8ce780be)
