### PR TITLE
Repopulate input fields of input forms on Sample page

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -26,6 +26,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - (System: administration) Docker commands can now be run without `sudo`.
 - (Application: GUI) The "System Monitoring" page now uses a Grafana dashboard to display metrics.
 - (Application: GUI) The "Fluidic Acquisition" page now uses a numeric text input instead of a slider for adjusting the "Pumped volume" setting, to make it easier to change the setting to a different exact value.
+- (Application: GUI) On the "Sample" page, the input fields of the "Sample Location"/"Net Throw Location"/"Net Retrieval Location"/"Culture Date and Time" panels no longer get cleared when pressing the "Validate" button.
 - (System) The PlanktoScope's machine name is now saved to `/var/lib/planktoscope/machine-name` instead of `/home/pi/.local/etc/machine-name`, and it's now saved without a trailing newline.
 
 ### Removed

--- a/software/node-red-dashboard/flows/adafruithat.json
+++ b/software/node-red-dashboard/flows/adafruithat.json
@@ -2282,7 +2282,8 @@
         "y": 580,
         "wires": [
             [
-                "14658615.47c862"
+                "14658615.47c862",
+                "3318a1aaa70fc2ee"
             ]
         ]
     },
@@ -2343,7 +2344,8 @@
         "y": 620,
         "wires": [
             [
-                "14658615.47c862"
+                "14658615.47c862",
+                "cc67c97f55a340d3"
             ]
         ]
     },
@@ -2403,7 +2405,8 @@
         "y": 660,
         "wires": [
             [
-                "14658615.47c862"
+                "14658615.47c862",
+                "9c8f370d124a55e4"
             ]
         ]
     },
@@ -3032,7 +3035,116 @@
         "y": 700,
         "wires": [
             [
-                "14658615.47c862"
+                "14658615.47c862",
+                "38616e738f4f615b"
+            ]
+        ]
+    },
+    {
+        "id": "3318a1aaa70fc2ee",
+        "type": "change",
+        "z": "b771c342.49603",
+        "name": "Repopulate input fields",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 580,
+        "wires": [
+            [
+                "c33f1124.af6688"
+            ]
+        ]
+    },
+    {
+        "id": "cc67c97f55a340d3",
+        "type": "change",
+        "z": "b771c342.49603",
+        "name": "Repopulate input fields",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 620,
+        "wires": [
+            [
+                "358908cd.416ab"
+            ]
+        ]
+    },
+    {
+        "id": "9c8f370d124a55e4",
+        "type": "change",
+        "z": "b771c342.49603",
+        "name": "Repopulate input fields",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 660,
+        "wires": [
+            [
+                "56d40584.eff4e4"
+            ]
+        ]
+    },
+    {
+        "id": "38616e738f4f615b",
+        "type": "change",
+        "z": "b771c342.49603",
+        "name": "Repopulate input fields",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 700,
+        "wires": [
+            [
+                "05c6aff2afbd69cf"
             ]
         ]
     },

--- a/software/node-red-dashboard/flows/pscopehat.json
+++ b/software/node-red-dashboard/flows/pscopehat.json
@@ -2282,7 +2282,8 @@
         "y": 580,
         "wires": [
             [
-                "14658615.47c862"
+                "14658615.47c862",
+                "a9fb1f4b83fc25a7"
             ]
         ]
     },
@@ -2343,7 +2344,8 @@
         "y": 620,
         "wires": [
             [
-                "14658615.47c862"
+                "14658615.47c862",
+                "ad54b89540460d27"
             ]
         ]
     },
@@ -2403,7 +2405,8 @@
         "y": 660,
         "wires": [
             [
-                "14658615.47c862"
+                "14658615.47c862",
+                "c21bf0244e67e40a"
             ]
         ]
     },
@@ -3035,7 +3038,116 @@
         "y": 700,
         "wires": [
             [
-                "14658615.47c862"
+                "14658615.47c862",
+                "f8044c35996322e6"
+            ]
+        ]
+    },
+    {
+        "id": "a9fb1f4b83fc25a7",
+        "type": "change",
+        "z": "b771c342.49603",
+        "name": "Repopulate input fields",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 580,
+        "wires": [
+            [
+                "c33f1124.af6688"
+            ]
+        ]
+    },
+    {
+        "id": "ad54b89540460d27",
+        "type": "change",
+        "z": "b771c342.49603",
+        "name": "Repopulate input fields",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 620,
+        "wires": [
+            [
+                "358908cd.416ab"
+            ]
+        ]
+    },
+    {
+        "id": "c21bf0244e67e40a",
+        "type": "change",
+        "z": "b771c342.49603",
+        "name": "Repopulate input fields",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 660,
+        "wires": [
+            [
+                "56d40584.eff4e4"
+            ]
+        ]
+    },
+    {
+        "id": "f8044c35996322e6",
+        "type": "change",
+        "z": "b771c342.49603",
+        "name": "Repopulate input fields",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 700,
+        "wires": [
+            [
+                "05c6aff2afbd69cf"
             ]
         ]
     },


### PR DESCRIPTION
This PR fixes #315 (and also fixes #314, which - based on the work done in this PR - I have determined is actually just a duplicate of #315) by feeding the outputs of the Node-RED dashboard's "Sample" page's input form nodes back as inputs into those nodes once the respective input forms are submitted.