### PR TITLE
Bump Python segmenter

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -9,6 +9,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Fixed
+
+- (Application: backend) The segmenter should no longer have file permissions errors when trying to read or write files in directories created by Docker or by the Python hardware controller.
+
 ## v2024.0.0-alpha.0 - 2024-02-06
 
 ### Added

--- a/software/distro/setup/base-os/forklift/install.sh
+++ b/software/distro/setup/base-os/forklift/install.sh
@@ -6,7 +6,7 @@
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 forklift_version="0.5.0"
 pallet_path="github.com/PlanktoScope/pallet-standard"
-pallet_version="v2024.0.0-alpha.0"
+pallet_version="29288ca"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | sudo tar -C /usr/bin -xz forklift

--- a/software/distro/setup/base-os/forklift/install.sh
+++ b/software/distro/setup/base-os/forklift/install.sh
@@ -4,9 +4,9 @@
 # distribution
 
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
-forklift_version="0.5.0"
+forklift_version="0.5.3"
 pallet_path="github.com/PlanktoScope/pallet-standard"
-pallet_version="29288ca"
+pallet_version="b1dd05d"
 
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_arm.tar.gz" \
   | sudo tar -C /usr/bin -xz forklift

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -62,6 +62,6 @@ cp -r "$repo_root/$directory" $HOME/PlanktoScope/$directory
 
 # Set up the segmenter
 # TODO: give forklift some way to make these directories ahead-of-time!
-mkdir -p $HOME/device-backend-logs/processing/segmenter
-mkdir -p $HOME/data/img
-mkdir -p $HOME/data/export
+# mkdir -p $HOME/device-backend-logs/processing/segmenter
+# mkdir -p $HOME/data/img
+# mkdir -p $HOME/data/export

--- a/software/distro/setup/planktoscope-app-env/python-backend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-backend/install.sh
@@ -59,9 +59,3 @@ cp "$HOME/device-backend/default-configs/$hardware_type-latest.hardware.json" \
 mkdir -p $HOME/PlanktoScope/scripts
 directory="scripts/raspimjpeg"
 cp -r "$repo_root/$directory" $HOME/PlanktoScope/$directory
-
-# Set up the segmenter
-# TODO: give forklift some way to make these directories ahead-of-time!
-# mkdir -p $HOME/device-backend-logs/processing/segmenter
-# mkdir -p $HOME/data/img
-# mkdir -p $HOME/data/export

--- a/software/node-red-dashboard/default-configs/v2.6.config.json
+++ b/software/node-red-dashboard/default-configs/v2.6.config.json
@@ -1,0 +1,20 @@
+{
+    "sample_project": "Project's name",
+    "sample_id": 1,
+    "sample_ship": "Vessel name",
+    "sample_operator": "Operator's name",
+    "sample_sampling_gear": "net",
+    "sample_gear_net_opening": 40,
+    "acq_id": 1,
+    "acq_instrument": "PlanktoScope v2.6",
+    "acq_celltype": 300,
+    "acq_minimum_mesh": 10,
+    "acq_maximum_mesh": 200,
+    "acq_volume": 1,
+    "object_depth_min": 1,
+    "object_depth_max": 2,
+    "process_id": 1,
+    "nb_frame": 100,
+    "sleep_before": 0.5,
+    "imaging_pump_volume": 0.01
+}


### PR DESCRIPTION
This PR bumps the distro's pallet-standard to incorporate the changes made by https://github.com/PlanktoScope/pallet-standard/pull/9 (and, in turn, https://github.com/PlanktoScope/device-pkgs/pull/8 and https://github.com/PlanktoScope/device-backend/pull/22).