### PR TITLE
Move tech specs in the docs to their own pages

### DIFF
--- a/documentation/docs/reference/hardware/changelog.md
+++ b/documentation/docs/reference/hardware/changelog.md
@@ -4,7 +4,7 @@ The design of the PlanktoScope's hardware has been evolving to fix usability iss
 
 ## v2.6
 
-This is the latest version of the PlanktoScope hardware, and it is the version currently sold by FairScope. It replaced the optical components so that the PlanktoScope produces higher-quality images.
+This is the latest version of the PlanktoScope hardware, and it is the version currently sold by FairScope. It replaced the optical components so that the PlanktoScope produces higher-quality images, and with slightly higher magnification.
 
 ## v2.5
 

--- a/documentation/docs/reference/hardware/changelog.md
+++ b/documentation/docs/reference/hardware/changelog.md
@@ -4,7 +4,7 @@ The design of the PlanktoScope's hardware has been evolving to fix usability iss
 
 ## v2.6
 
-This is the latest version of the PlanktoScope hardware, and it is the version currently sold by FairScope. It replaced the optical components so that the PlanktoScope produces higher-quality images, and with slightly higher magnification.
+This is the latest version of the PlanktoScope hardware, and it is the version currently sold by FairScope. It replaced the optical components so that the PlanktoScope produces higher-quality images.
 
 ## v2.5
 

--- a/documentation/docs/reference/hardware/product-specs.md
+++ b/documentation/docs/reference/hardware/product-specs.md
@@ -1,0 +1,283 @@
+# Product Specifications
+
+Product specifications for the PlanktoScope hardware are listed below for each hardwaare version. For more information on each hardware version, refer to the [hardware changelog](./changelog.md).
+
+## v2.6
+
+Overview:
+
+- Weight: 3.5 kg
+- Enclosure:
+
+    - Dimensions: 27.5 cm (length) x 12.5 cm (width) x 10.5 cm (height)
+    - Material: bamboo plywood
+    - Fabrication process: CNC milling
+
+### Functionalities
+
+- Automated image acquisition, with a motorized pump and an embedded computer
+- Precise focus adjustment, with motorized linear actuators
+- Continuous mixing of input sample to prevent sedimentation of heavier particles, with a USB-powered bubbler
+- On-board image processing, with the embedded computer
+- Local Wi-Fi network hotspot for local operation from a connected phone, tablet or laptop, with the embedded computer
+- Internet connectivity via Wi-Fi or Ethernet for remote operation, with the embedded computer
+
+### Subsystems
+
+![planktoscope_hero](../../images/project_description/planktoscope_architecture.png)
+
+Optics:
+
+- Imaging characteristics:
+
+    - Optical magnification: 1.33
+    - Field of view: 3062 µm x 2295 µm
+    - Optical pixel size: 0.75 µm
+    - Depth of field: 95 µm
+
+- Internal camera: [Raspberry Pi High Quality Camera](https://www.raspberrypi.com/products/raspberry-pi-high-quality-camera/)
+
+    - Sensor: Sony IMX477R
+    - Resolution: 12.3 Megapixels (4056 x 3040 pixels)
+
+- Lenses:
+
+    - Objective lens: 12 mm focal length, M12
+    - Tube lens: 25 mm focal length, M12
+    - Lens mount: M12x0.5
+
+- Illumination: [white LED](https://www.adafruit.com/product/754)
+
+Fluidics:
+
+- Flow cell: capillary with rectangular cross-section
+
+    - Thickness: 300 µm
+    - Material: glass
+
+- Internal tubing:
+
+    - Material: Tygon S3 (contains no BPA or phthalates)
+    - Dimensions: 1.6 mm (1/16") inner diameter, 3.2 mm (1/8") outer diameter
+    - Connectors: Luer lock
+
+- Peristaltic pump
+- Sample intake capacity: 20 mL
+
+Other internal electronics:
+
+- Embedded computer: [Raspberry Pi 4 Model B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/)
+
+    - Processor: Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.8 GHz
+    - Memory: 4 GB RAM
+    - Storage: 128 GB capacity (micro-SD card, UHS speed class 3)
+
+- Control board: [PlanktoScope HAT](./hat.md) v1.2
+
+External interfaces & connectivity:
+
+- Expansion: 2 USB 3.0 ports, 2 USB 2.0 ports
+- Wired networking: Gigabit Ethernet
+- Wireless networking: 2.4 GHz and 5.0 GHz 802.11ac Wi-Fi
+- Power input: 12 V DC, up to 4 A of current draw (5.1 x 2.2 mm DC barrel jack, center positive)
+- Latching push-button switch to toggle power
+
+External AC-to-DC power adapter:
+
+- Input: 100-240 V AC, 50-60 Hz (IEC 60320 C8 socket)
+- Output: 12 V DC, up to 4 A of current output (5.1 x 2.2 mm DC barrel jack, center positive)
+- Dimensions: 126 mm (length) x 52 mm (width) x 35.5 mm (height)
+- Weight: 0.25 kg
+
+### System performance
+
+Image acquisition throughput:
+
+- Volume of sample measured: 2.1 µL per acquired image
+- Volume of sample pumped: ~15 µL per acquired image
+- Maximum image acquisition rate: ~60 images/min
+
+Samples:
+
+- Object size range:
+
+    - Minimum for taxonomy: ~20 µm diameter for round objects
+    - Maximum: ~200 µm diameter for round objects (larger objects will clog the flow cell)
+
+## v2.5
+
+Overview:
+
+- Enclosure:
+
+    - Dimensions: 27.5 cm (length) x 12.5 cm (width) x 10.5 cm (height)
+    - Material: bamboo plywood
+    - Fabrication process: CNC milling
+
+### Functionalities
+
+- Automated image acquisition, with a motorized pump and an embedded computer
+- Precise focus adjustment, with motorized linear actuators
+- Continuous mixing of input sample to prevent sedimentation of heavier particles, with a USB-powered bubbler
+- On-board image processing, with the embedded computer
+- Local Wi-Fi network hotspot for local operation from a connected phone, tablet or laptop, with the embedded computer
+- Internet connectivity via Wi-Fi or Ethernet for remote operation, with the embedded computer
+
+### Subsystems
+
+![planktoscope_hero](../../images/project_description/planktoscope_architecture.png)
+
+Optics:
+
+- Imaging characteristics:
+
+    - Field of view: 3670 µm x 2675 µm
+    - Optical pixel size: 0.88 µm
+
+- Internal camera: [Raspberry Pi High Quality Camera](https://www.raspberrypi.com/products/raspberry-pi-high-quality-camera/)
+
+    - Sensor: Sony IMX477R
+    - Resolution: 12.3 Megapixels (4056 x 3040 pixels)
+
+- Lenses:
+
+    - Objective lens: 16 mm focal length, M12
+    - Tube lens: 25 mm focal length, M12
+    - Lens mount: M12x0.5
+
+- Illumination: [white LED](https://www.adafruit.com/product/754)
+
+Fluidics:
+
+- Flow cell: capillary with rectangular cross-section
+
+    - Thickness: 300 µm
+    - Material: glass
+
+- Internal tubing:
+
+    - Material: Tygon S3 (contains no BPA or phthalates)
+    - Dimensions: 1.6 mm (1/16") inner diameter, 3.2 mm (1/8") outer diameter
+    - Connectors: Luer lock
+
+- Peristaltic pump
+- Sample intake capacity: 20 mL
+
+Other internal electronics:
+
+- Embedded computer: [Raspberry Pi 4 Model B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/)
+
+    - Processor: Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.8 GHz
+    - Memory: 4 GB RAM
+    - Storage: 128 GB capacity (micro-SD card, UHS speed class 3)
+
+- Control board: [PlanktoScope HAT](./hat.md) v1.2
+
+External interfaces & connectivity:
+
+- Expansion: 2 USB 3.0 ports, 2 USB 2.0 ports
+- Wired networking: Gigabit Ethernet
+- Wireless networking: 2.4 GHz and 5.0 GHz 802.11ac Wi-Fi
+- Power input: 12 V DC, up to 4 A of current draw (5.1 x 2.2 mm DC barrel jack, center positive)
+- Latching push-button switch to toggle power
+
+External AC-to-DC power adapter:
+
+- Input: 100-240 V AC, 50-60 Hz (IEC 60320 C8 socket)
+- Output: 12 V DC, up to 4 A of current output (5.1 x 2.2 mm DC barrel jack, center positive)
+- Dimensions: 126 mm (length) x 52 mm (width) x 35.5 mm (height)
+- Weight: 0.25 kg
+
+### System performance
+
+Image acquisition throughput:
+
+- Volume of sample pumped: ~15 µL per acquired image
+- Maximum image acquisition rate: ~60 images/min
+
+Samples:
+
+- Object size range:
+
+    - Maximum: ~200 µm diameter for round objects (larger objects will clog the flow cell)
+
+## v2.1
+
+Overview:
+
+- Enclosure:
+
+    - Dimensions: ~32 cm (length) x ~5.5 cm (width) x ~15 cm (height)
+    - Material: acrylic, plywood, or fiberboard
+    - Fabrication process: laser cutting
+
+### Functionalities
+
+- Automated image acquisition, with a motorized pump and an embedded computer
+- Precise focus adjustment, with motorized linear actuators
+- On-board image processing, with the embedded computer
+- Local Wi-Fi network hotspot for local operation from a connected phone, tablet or laptop, with the embedded computer
+- Internet connectivity via Wi-Fi or Ethernet for remote operation, with the embedded computer
+
+### Subsystems
+
+Optics:
+
+- Imaging characteristics:
+
+    - Field of view: 2300 µm x 1730 µm
+    - Optical pixel size: 0.75 µm
+
+- Internal camera: [Raspberry Pi Camera Module 2](https://www.raspberrypi.com/products/camera-module-v2/)
+
+    - Sensor: Sony IMX219
+    - Resolution: 8 Megapixels (3280 x 2464 pixels)
+
+- Lenses:
+
+    - Objective lens: 12 mm focal length, M12
+    - Tube lens: 25 mm focal length, M12
+    - Lens mount: M12x0.5
+
+- Illumination: [white LED](https://www.adafruit.com/product/754)
+
+Fluidics:
+
+- Flow cell: [ibidi µ-Slide I Luer channel slide](https://ibidi.com/channel-slides/50-141--slide-i-luer.html)
+
+    - Thickness: 200 µm, 400 µm, 600 µm, or 800 µm
+    - Material: Plastic (no surface modification)
+
+- Internal tubing:
+
+    - Material: Tygon S3 (contains no BPA or phthalates)
+    - Dimensions: 1.6 mm (1/16") inner diameter, 3.2 mm (1/8") outer diameter
+    - Connectors: Luer lock
+
+- Peristaltic pump
+- Sample intake capacity: 20 mL
+
+Other internal electronics:
+
+- Embedded computer: [Raspberry Pi 4 Model B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/specifications/)
+
+    - Processor: Broadcom BCM2711, Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.8 GHz
+    - Memory: 4 GB RAM
+
+- Control boards:
+
+    - [Adafruit Stepper Motor HAT](https://www.adafruit.com/product/2348)
+
+        - Input voltage: 5 - 12 V DC
+        - Output voltage: 4.5 - 13.5 V DC
+        - Output current: up to 1.2 A continuous, 3 A peak
+
+    - [Adafruit Ultimate GPS HAT](https://www.adafruit.com/product/2324)
+
+External interfaces & connectivity:
+
+- Expansion: 2 USB 3.0 ports, 2 USB 2.0 ports, 2 micro-HDMI ports
+- Wired networking: Gigabit Ethernet
+- Wireless networking: 2.4 GHz and 5.0 GHz 802.11ac Wi-Fi
+- Power input for embedded computer: 5 V DC, up to 3 A of current draw (USB-C)
+- Power input for motors: 5 - 12 V DC, depending on pump motor (5.1 x 2.2 mm DC barrel jack, center positive)

--- a/documentation/docs/reference/index.md
+++ b/documentation/docs/reference/index.md
@@ -36,20 +36,6 @@ Here are some key features of the PlanktoScope:
 - automatic sampling via peristaltic pump
 - the case is made of wood fiberboard
 
-### Software
-
-- [Debian](https://www.raspberrypi.com/software/operating-systems/) based Embedded Linux operating
-- [Node-Red](https://nodered.org/) based user interface
-- [Python](https://www.python.org/) Image processing service and cloud connection
-
-### Characteristic
-
-- Focus stage control
-- Pump control
-- Automatic image capture
-- Automatic segmentation, optimization and object detection
-- Control via smartphone or tablet
-
 ## Areas of Application
 
 - Plankton analysis of small animals and algae living in water

--- a/documentation/docs/reference/index.md
+++ b/documentation/docs/reference/index.md
@@ -14,33 +14,3 @@ Here are some key features of the PlanktoScope:
 6. **WiFi-enabled**: The PlanktoScope can be controlled from any WiFi-enabled device, making it easy to use and deploy in a variety of settings.
 7. **Portable**: The PlanktoScope is small and portable, making it easy to transport and use in the field.
 8. **Ease of use**: The PlanktoScope is designed to be easy to use, with instructions for assembly and use available on the PlanktoScope website.
-
-## Device specification
-
-![planktoscope_hero](../images/project_description/planktoscope_architecture.png)
-
-### Size
-
-- height: 105 mm
-- wide: 275 mm
-- depth: 125 mm
-
-### Hardware
-
-- [4 Core ARM-Cortex-A72 Processor](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) with 1,50 GHz
-- 4 GB Arbeitsspeicher (depending on the purchased version)
-- 64 GB Flash memory (depending on the purchased version)
-- [Sony IMX477R](https://www.raspberrypi.com/products/raspberry-pi-high-quality-camera/) Image sensor with 12.3MP
-- M12 mount optics with 16 and 25 mm lenses
-- Automatic focus via linear guide
-- automatic sampling via peristaltic pump
-- the case is made of wood fiberboard
-
-## Areas of Application
-
-- Plankton analysis of small animals and algae living in water
-- Mobile use via external power supply
-
-## System Requirements
-
-- a Web-Browser to control the device (like a Notebook, Smartphone or Tablet)

--- a/documentation/docs/reference/software/product-specs.md
+++ b/documentation/docs/reference/software/product-specs.md
@@ -1,0 +1,103 @@
+# Product Specifications
+
+Product specifications for the PlanktoScope software are listed below for ranges of software version numbers. To see software versions listed individually in chronological order, refer to the [project release notes](https://github.com/PlanktoScope/PlanktoScope/releases) or the [software changelog](./changelog.md).
+
+## v2023.9.0 - v2024.0.0
+
+### Functionalities
+
+Regular operation:
+
+- Image acquisition: stop-flow imaging
+- On-board image processing: detection and segmentation of objects (batch-processing only)
+- User interfacing: graphical interface accessible through web browser of a connected phone, tablet, or computer
+
+Advanced operations:
+
+- User interfacing: web browser interfaces for system administration, system monitoring, and troubleshooting
+- Automation: MQTT-based API
+- Application deployment: ability to add software as OCI containers using Docker
+
+### Base operating system
+
+- Distro: Raspberry Pi OS 11 (bullseye)
+- Binary target architecture: 32-bit only (armhf, also known as armv7)
+
+### Supported hardware
+
+Minimum for image acquisition (but not sufficient for on-board image processing):
+
+- PlanktoScope: hardware v2.1 with Raspberry Pi 4 Model B computer
+- Memory: 1 GB RAM
+- Storage: 8 GB capacity
+
+Minimum for full functionality, including on-board image processing:
+
+- Memory: 4 GB RAM
+
+Recommended:
+
+- PlanktoScope: hardware v2.5 or v2.6 with Raspberry Pi 4 Model B computer
+- Storage: 32 GB capacity
+
+Forwards-incompatibilities:
+
+- These software versions are unable to run on the Raspberry Pi 5 computer.
+
+Backwards-incompatibilities:
+
+- These software versions might still work on a Raspberry Pi 3 Model B+ computer or a Raspberry Pi 4 Model B computer with 1 GB of RAM, but compatibility is not tested.
+
+### System performance
+
+With minimum supported hardware for full functionality:
+
+- On-board image processing: a dataset of 400 raw images is processed in approximately 1.5 to 2 hours
+
+## v2.3
+
+### Functionalities
+
+Regular operation:
+
+- Image acquisition: stop-flow imaging
+- On-board image processing: detection and segmentation of objects (batch-processing only)
+- User interfacing: graphical interface accessible through web browser of a connected phone, tablet, or computer
+
+Advanced operations:
+
+- Automation: MQTT-based API
+
+### Base operating system
+
+- Distro: Raspberry Pi OS 11 (bullseye)
+- Binary target architecture: 32-bit only (armhf, also known as armv7)
+
+### Supported hardware
+
+Minimum for image acquisition (but not sufficient for on-board image processing):
+
+- PlanktoScope: hardware v2.1 with Raspberry Pi 3 Model B+ computer
+- Memory: 1 GB RAM
+- Storage: 8 GB capacity
+
+Minimum for full functionality, including on-board image processing:
+
+- PlanktoScope: hardware v2.1 with Raspberry Pi 4 Model B computer
+- Memory: 4 GB RAM
+
+Recommended for full functionality:
+
+- PlanktoScope: hardware v2.5 or v2.6
+- Storage: 32 GB capacity
+
+Forwards-incompatibilities:
+
+- This software version is unable to run on the Raspberry Pi 5 computer.
+- This software version is incompatible with Adafruit Stepper Motor HATs (used in PlanktoScope hardware v2.1) manufactured after mid-2022.
+
+### System performance
+
+With minimum supported hardware for full functionality:
+
+- On-board image processing: a dataset of 400 raw images is processed in approximately 1.5 to 2 hours

--- a/documentation/docs/reference/software/product-specs.md
+++ b/documentation/docs/reference/software/product-specs.md
@@ -8,9 +8,10 @@ Product specifications for the PlanktoScope software are listed below for ranges
 
 Regular operation:
 
-- Image acquisition: stop-flow imaging
+- Image acquisition: stop-flow imaging, JPEG image output
 - On-board image processing: detection and segmentation of objects (batch-processing only)
 - User interfacing: graphical interface accessible through web browser of a connected phone, tablet, or computer
+- Export of data for uploading to EcoTaxa
 
 Advanced operations:
 
@@ -60,9 +61,10 @@ With minimum supported hardware for full functionality:
 
 Regular operation:
 
-- Image acquisition: stop-flow imaging
+- Image acquisition: stop-flow imaging, JPEG image output
 - On-board image processing: detection and segmentation of objects (batch-processing only)
 - User interfacing: graphical interface accessible through web browser of a connected phone, tablet, or computer
+- Export of data for uploading to EcoTaxa
 
 Advanced operations:
 

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Planktoscope HAT: reference/hardware/hat.md
       - Changelog: reference/hardware/changelog.md
     - Software:
+      - Product Specifications: reference/software/product-specs.md
       # (@ethanjli) I'm hiding this page because I don't consider it ready for public use:
       # - MQTT Messages: reference/software/mqtt-api.md
       - Changelog: reference/software/changelog.md

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
   - Technical Reference:
     - reference/index.md
     - Hardware:
+      - Product Specifications: reference/hardware/product-specs.md
       - Planktoscope HAT: reference/hardware/hat.md
       - Changelog: reference/hardware/changelog.md
     - Software:


### PR DESCRIPTION
This PR updates the documentation site by removing technical specifications from the "Technical Reference" page, and instead creating pages in the "Hardware" and "Software" sections of the technical reference with "Product Specifications" (which are technical specifications but also include some information about functionalities). The software specs page provides useful information about hardware compatibility, while the hardware spccs page includes information currently listed on the FairScope website as well as other information which was frequently asked about by people visiting the FairScope booth at the Ocean Sciences Meeting a few weeks ago.

Some information is omitted where I couldn't find/measure the corresponding values (e.g. the weight of the v2.1 PlanktoScope).