### PR TITLE
Fix various small issues in the Node-RED dashboard

### DIFF
--- a/software/node-red-dashboard/default-configs/planktoscopehat-latest.config.json
+++ b/software/node-red-dashboard/default-configs/planktoscopehat-latest.config.json
@@ -6,7 +6,7 @@
     "sample_sampling_gear": "net",
     "sample_gear_net_opening": 40,
     "acq_id": 1,
-    "acq_instrument": "PlanktoScope v2.5",
+    "acq_instrument": "PlanktoScope v2.6",
     "acq_celltype": 300,
     "acq_minimum_mesh": 10,
     "acq_maximum_mesh": 200,

--- a/software/node-red-dashboard/flows/adafruithat.json
+++ b/software/node-red-dashboard/flows/adafruithat.json
@@ -4628,7 +4628,7 @@
         "z": "bccd1f23.87219",
         "name": "WB Red input",
         "label": "WB: Red",
-        "tooltip": "From 1.0 to 8.0",
+        "tooltip": "From 0.0 to 8.0",
         "group": "8c38a81e.9897a8",
         "order": 6,
         "width": 4,
@@ -4654,7 +4654,7 @@
         "z": "bccd1f23.87219",
         "name": "WB Blue input",
         "label": "WB: Blue",
-        "tooltip": "From 1.0 to 64.0",
+        "tooltip": "From 0.0 to 64.0",
         "group": "8c38a81e.9897a8",
         "order": 7,
         "width": 4,
@@ -4756,7 +4756,7 @@
         "rules": [
             {
                 "t": "btwn",
-                "v": "1.0",
+                "v": "0.0",
                 "vt": "num",
                 "v2": "8.0",
                 "v2t": "num"
@@ -4791,7 +4791,7 @@
         "rules": [
             {
                 "t": "btwn",
-                "v": "1.0",
+                "v": "0.0",
                 "vt": "num",
                 "v2": "8.0",
                 "v2t": "num"

--- a/software/node-red-dashboard/flows/planktoscopehat.json
+++ b/software/node-red-dashboard/flows/planktoscopehat.json
@@ -4744,7 +4744,7 @@
         "z": "bccd1f23.87219",
         "name": "WB Blue input",
         "label": "WB: Blue",
-        "tooltip": "From 1.0 to 64.0",
+        "tooltip": "From 0.0 to 64.0",
         "group": "8c38a81e.9897a8",
         "order": 7,
         "width": 4,
@@ -4842,7 +4842,7 @@
         "z": "bccd1f23.87219",
         "name": "WB Red input",
         "label": "WB: Red",
-        "tooltip": "From 1.0 to 8.0",
+        "tooltip": "From 0.0 to 8.0",
         "group": "8c38a81e.9897a8",
         "order": 6,
         "width": 4,
@@ -4872,7 +4872,7 @@
         "rules": [
             {
                 "t": "btwn",
-                "v": "1.0",
+                "v": "0.0",
                 "vt": "num",
                 "v2": "8.0",
                 "v2t": "num"
@@ -4907,7 +4907,7 @@
         "rules": [
             {
                 "t": "btwn",
-                "v": "1.0",
+                "v": "0.0",
                 "vt": "num",
                 "v2": "8.0",
                 "v2t": "num"


### PR DESCRIPTION
This PR fixes some small issues [reported by Tanguy Cebron](https://planktoscope.slack.com/archives/C01V5ENKG0M/p1711526219960609):

- In development/testing for #380 and https://github.com/PlanktoScope/device-backend/pull/19 I had determined that the minimum allowed red/blue white balance gain was 0.0, while the Node-RED dashboard's input-validation logic currently enforces a minimum value of 1.0. This PR reduces the minimum value to 0.0.
- https://github.com/PlanktoScope/device-backend/commit/118ea1e13212826319fa3b818987124fe2d4dfae changed the default planktoscopehat `hardware.json` configuration file to match the v2.6 hardware; this PR updates the default planktoscopehat `config.json` configuration file specify the v2.6 hardware, for consistency.