### PR TITLE
Make small improvements to the software install docs

### DIFF
--- a/documentation/docs/setup/software/nonstandard-install.md
+++ b/documentation/docs/setup/software/nonstandard-install.md
@@ -14,7 +14,7 @@ If you have not used the PlanktoScope software before, you should first start wi
 
 In order to complete the non-standard setup process, you will need all of the following:
 
-1. A Raspberry Pi computer. We only test to ensure that the PlanktoScope software works on the Raspberry Pi 4; it may or may not work on the Raspberry Pi 3.
+1. A Raspberry Pi computer. We only test to ensure that the PlanktoScope software works on the Raspberry Pi 4; it may or may not work on the Raspberry Pi 3, and it does not yet work on the Raspberry Pi 5.
 2. A keyboard connected to your Raspberry Pi.
 3. A display connected to your Raspberry Pi.
 4. A micro-SD card for your Raspberry Pi.

--- a/documentation/docs/setup/software/nonstandard-install.md
+++ b/documentation/docs/setup/software/nonstandard-install.md
@@ -25,9 +25,17 @@ In order to complete the non-standard setup process, you will need all of the fo
 
 ### Download a Raspberry Pi OS SD card image
 
-The setup scripts for the PlanktoScope software distribution assume that you will be setting up the PlanktoScope software on a 32-bit version of the Raspberry Pi OS with Debian version 11 (bullseye), preferably the version released on 2023-05-03. The latest version of Raspberry Pi OS, with Debian version 12 (bookworm), can be downloaded from [the Raspberry Pi Operating system images page](https://www.raspberrypi.com/software/operating-systems/), but the setup scripts do not yet work on Debian version 12; that page also has links named "Archive" under the download buttons where you can find older versions with Debian version 11. You should choose between the ["Raspberry Pi OS with desktop"](https://downloads.raspberrypi.com/raspios_armhf/images/raspios_armhf-2023-05-03/2023-05-03-raspios-bullseye-armhf.img.xz), ["Raspberry Pi OS with desktop and recommended software"](https://downloads.raspberrypi.com/raspios_full_armhf/images/raspios_full_armhf-2023-05-03/2023-05-03-raspios-bullseye-armhf-full.img.xz), or ["Raspberry Pi OS Lite"](https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2023-05-03/2023-05-03-raspios-bullseye-armhf-lite.img.xz) options, depending on your needs.
+The setup scripts for the PlanktoScope software distribution assume that you will be setting up the PlanktoScope software on a 32-bit version of the Raspberry Pi OS with Debian version 11 (bullseye), preferably the version released on 2023-05-03. You can choose any of the following three variants of that version of the Raspberry Pi OS, depending on your needs:
+
+- ["Raspberry Pi OS with desktop"](https://downloads.raspberrypi.com/raspios_armhf/images/raspios_armhf-2023-05-03/2023-05-03-raspios-bullseye-armhf.img.xz)
+- ["Raspberry Pi OS with desktop and recommended software"](https://downloads.raspberrypi.com/raspios_full_armhf/images/raspios_full_armhf-2023-05-03/2023-05-03-raspios-bullseye-armhf-full.img.xz)
+- ["Raspberry Pi OS Lite"](https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2023-05-03/2023-05-03-raspios-bullseye-armhf-lite.img.xz)
 
 The standard PlanktoScope software SD card images are built on the Raspberry Pi OS Lite image, which only provides a command-line interface, without a graphical desktop environment or web browser; because the PlanktoScope's graphical user interface must be accessed from a web browser, you might prefer to use the "Raspberry Pi OS with desktop" image in order to have a graphical desktop environment with a web browser. This would allow you to operate the PlanktoScope by plugging in a display, keyboard, and mouse to your Raspberry Pi; otherwise, you will have to connect to the PlanktoScope from another device over Ethernet or Wi-Fi in order access the PlanktoScope's graphical user interface.
+
+!!! warning
+
+    The latest version of Raspberry Pi OS, with Debian version 12 (bookworm), can be downloaded from [the Raspberry Pi Operating system images page](https://www.raspberrypi.com/software/operating-systems/), but the PlanktoScope software setup scripts do not yet work on Debian version 12; that page also has links named "Archive" under the download buttons where you can find older versions with Debian version 11 (bullseye) under the "Raspberry Pi OS (Legacy)" section; those links are the same as the links we listed above. You should make sure you download a 32-bit version of Raspberry Pi OS Bullseye, as the PlanktoScope software setup scripts do not yet work with 64-bit versions of the Raspberry Pi OS!
 
 ### Write the OS image to an SD card
 

--- a/documentation/docs/setup/software/nonstandard-install.md
+++ b/documentation/docs/setup/software/nonstandard-install.md
@@ -33,9 +33,9 @@ The standard PlanktoScope software SD card images are built on the Raspberry Pi 
 
 Next, you will need to write your downloaded Raspberry Pi OS image file to your microSD card. Plug your microSD card into your computer; you may need to use a microSD-to-SD-card adapter, and/or an SD-card-to-USB adapter.
 
-To use a graphical application to write the image file to your microSD card, you can install balenaEtcher or the Raspberry Pi imager. Download the latest version of [balenaEtcher](https://www.balena.io/etcher/) or the [Raspberry Pi Imager](https://www.raspberrypi.com/software/) and install it. Then open balenaEtcher or the Raspberry Pi Imager. Select the Raspberry Pi OS image file (likely a `.img`, `.img.gz`, or `.img.xz` file) you just downloaded, and select the SD card you want to write the Raspberry Pi OS image to. Review your selections and click the "Flash!" or "Write" button to begin writing the Raspberry Pi OS image to the SD card. The process should take several minutes.
+To use a graphical application to write the image file to your microSD card, you can install the Raspberry Pi imager. Download the latest version of the [Raspberry Pi Imager](https://www.raspberrypi.com/software/), install it, and start it. Select the Raspberry Pi OS image file (likely a `.img`, `.img.gz`, or `.img.xz` file) you just downloaded, and select the SD card you want to write the Raspberry Pi OS image to. Review your selections and click the appropriate button to begin writing the Raspberry Pi OS image to the SD card. The process should take several minutes.
 
-If you'd instead prefer to write the image file to your microSD card from a command-line tool, you could instead use ddrescue on a Debian-based system, e.g. as follows:
+If you'd instead prefer to write the image file to your microSD card from a command-line tool, you could instead use a tool like `ddrescue` on a Debian-based system, e.g. as follows:
 
 ```
 gunzip planktoscope-v2.3-final.img.gz

--- a/documentation/docs/setup/software/standard-install.md
+++ b/documentation/docs/setup/software/standard-install.md
@@ -23,9 +23,7 @@ Each released version of the PlanktoScope software distribution has downloadable
 
 ### Write the image to the SD card
 
-To write the image file to your microSD card, you can install balenaEtcher or the Raspberry Pi imager.
-
-Here are instructions for using the Raspberry Pi Imager:
+To write the image file to your microSD card:
 
 1. Download, install, and start the latest version of the [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
 2. Plug your microSD card into your computer; you may need to use a microSD-to-SD-card adapter, and/or an SD-card-to-USB adapter.
@@ -35,15 +33,6 @@ Here are instructions for using the Raspberry Pi Imager:
 6. Press the "Next" button. A pop-up dialog should appear asking if you would like to customize the OS. You should probably press the "No" button unless you are already experienced with the PlanktoScope software, because most of the settings inside don't matter to typical users of the PlanktoScope software, and because it's possible to break the software with incorrect settings.
 7. A pop-up dialog should appear asking you to confirm whether you selected the correct SD card and want to wipe all data on the SD card in order to write the PlanktoScope SD card image to your SD card. If you are ready, press the "Yes" button.
 8. The Raspberry Pi Imager will begin overwriting your SD card with the PlanktoScope SD card image. This will take a while to finish.
-
-Here are instructions for using balenaEtcher:
-
-1. Download, install, and start [balenaEtcher](https://www.balena.io/etcher/).
-2. Plug your microSD card into your computer; you may need to use a microSD-to-SD-card adapter, and/or an SD-card-to-USB adapter.
-3. Open balenaEtcher
-4. Select the SD card image file which you had download in the previous section.
-5. Select the SD card you wish to write your image to.
-6. Review your selections and click 'Flash!' to begin writing data to the SD card.
 
 Once flashing is complete, unmount the SD card and remove it from the computer.
 


### PR DESCRIPTION
This PR makes various small usability improvements to the standard and non-standard software installation instructions in the PlanktoScope project docs; these improvements were requested in the [2024-03-28 software meeting](https://docs.google.com/document/d/1Iba0_9yNFEDdp1Qy8IYlLP43Ga0DnDr3CdavWV0QGZY/edit#heading=h.2qje39kpb6c2).