### PR TITLE
Temporarily disable MkDocs social preview cards

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -100,7 +100,10 @@ plugins:
       minify_html: true
   - privacy
   - social:
-      enabled: !ENV [DOCS_DEPLOY, false]
+      # Currently social previews are broken due to Google Fonts (for details, refer to
+      # https://github.com/squidfunk/mkdocs-material/issues/6983):
+      # enabled: !ENV [DOCS_DEPLOY, false]
+      enabled: false
   - search
 
 markdown_extensions:


### PR DESCRIPTION
This PR temporarily disables the MkDocs `social` plugin as a workaround for https://github.com/squidfunk/mkdocs-material/issues/6983 , because today our docs site deployments started failing in bee778d172f7b31b3a2acac14f2edc1a5e71ca0b.