### PR TITLE
Try to re-enable MkDocs social preview cards

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -110,10 +110,7 @@ plugins:
       minify_html: true
   - privacy
   - social:
-      # Currently social previews are broken due to Google Fonts (for details, refer to
-      # https://github.com/squidfunk/mkdocs-material/issues/6983):
-      # enabled: !ENV [DOCS_DEPLOY, false]
-      enabled: false
+      enabled: !ENV [DOCS_DEPLOY, false]
   - search
 
 markdown_extensions:

--- a/documentation/poetry.lock
+++ b/documentation/poetry.lock
@@ -692,13 +692,13 @@ pyyaml = "*"
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.12"
+version = "9.5.16"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.12-py3-none-any.whl", hash = "sha256:d6f0c269f015e48c76291cdc79efb70f7b33bbbf42d649cfe475522ebee61b1f"},
-    {file = "mkdocs_material-9.5.12.tar.gz", hash = "sha256:5f69cef6a8aaa4050b812f72b1094fda3d079b9a51cf27a247244c03ec455e97"},
+    {file = "mkdocs_material-9.5.16-py3-none-any.whl", hash = "sha256:32fce3cd8ecbd5dca6e5887cc0cf5bc78707a36f7d0f6f1bbbe9edaf428b8055"},
+    {file = "mkdocs_material-9.5.16.tar.gz", hash = "sha256:8b89b639592660f24657bb058de4aff0060cd0383148f8f51711201730f17503"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
This PR follows up on #387 by upgrading mkdocs-material to 9.5.16, which adds a fix to hopefully restore Google Fonts downloading functionality (which is needed by the plugin for the social preview cards)