### PR TITLE
Bump version numbers for v2024.0.0-alpha.2

### DIFF
--- a/software/distro/setup/base-os/forklift/install.sh
+++ b/software/distro/setup/base-os/forklift/install.sh
@@ -11,7 +11,7 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 forklift_version="0.7.0"
 pallet_path="github.com/PlanktoScope/pallet-standard"
-pallet_version="0f7dcad"
+pallet_version="v2024.0.0-alpha.2"
 
 arch="$(dpkg --print-architecture | sed -e 's/armhf/arm/' -e 's/aarch64/arm64/')"
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_${arch}.tar.gz" \

--- a/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
@@ -32,7 +32,7 @@ $POETRY_VENV/bin/pip install poetry==1.7.1
 
 # Download device-backend monorepo
 backend_repo="github.com/PlanktoScope/device-backend"
-backend_version="b3ceace" # this should be either a version tag, branch name, or commit hash
+backend_version="v2024.0.0-alpha.2" # this should be either a version tag, branch name, or commit hash
 git clone "https://$backend_repo" $HOME/device-backend --no-checkout --filter=blob:none
 git -C $HOME/device-backend checkout --quiet $backend_version
 

--- a/software/node-red-dashboard/package.json
+++ b/software/node-red-dashboard/package.json
@@ -1,7 +1,7 @@
 {
     "name": "planktoscope-node-red-dashboard",
     "description": "PlanktoScope graphical user interface",
-    "version": "2024.0.0-alpha.1",
+    "version": "2024.0.0-alpha.2",
     "dependencies": {
         "node-red-contrib-dir2files": "^0.3.0",
         "node-red-contrib-gpsd": "^1.0.4",


### PR DESCRIPTION
To test this PR, run the following command on a fresh installation of Raspberry Pi OS bullseye (replacing `planktoscopehat` with `adafruithat` if installing on an Adafruit HAT-based PlanktoScope):
```
wget -O - https://install.planktoscope.community/distro.sh | \
  sh -s -- -y -v release/v2024.0.0-alpha.1 -H planktoscopehat
```
Or, for a more reproducible but less convenient command which will work the same even if/when the install script is updated in the future, run:
```
wget -O - https://raw.githubusercontent.com/PlanktoScope/install.planktoscope.community/v2024.0.0-alpha.1/distro.sh | \
  sh -s -- -y -t 9499e6b -v TBD -H planktoscopehat
```