### PR TITLE
Remove FAQ item about PlanktoScope cost

### DIFF
--- a/documentation/docs/faq.md
+++ b/documentation/docs/faq.md
@@ -6,10 +6,6 @@ This FAQ has been compiled to answer common questions about the PlanktoScope pro
 
 You can purchase a PlanktoScope - either as a kit of parts to assemble yourself or as a fully preassembled device - from a small business called [FairScope](https://www.fairscope.com/), which was started by the inventor of the PlanktoScope in order to make PlanktoScopes easier to obtain. For more information, please refer to our page on [how to obtain a PlanktoScope](setup/index.md).
 
-## How much money does a PlanktoScope cost?
-
-For pricing of PlanktoScopes and PlanktoScope assembly kits from FairScope, refer to [the FairScope website](https://www.fairscope.com/). If you purchase all the parts to build a single PlanktoScope yourself, the cost of parts can be as low as USD 400 or USD 800 depending on the type of PlanktoScope you build.
-
 ## Where do I get support or find the necessary tools to build PlanktoScope?
 
 To find the necessary tools and knowledge to produce the PlanktoScope, consider visiting a [Fablab](https://fablabs.io/labs) or [Hackspaces](https://wiki.hackerspaces.org/List_of_Hacker_Spaces) in your region. These organizations often have a culture of openness and may be willing to support you with your project.


### PR DESCRIPTION
This PR reverts a change I had made in #274 by removing the documentation site's FAQ question about the cost of a PlanktoScope, to implement a change which @tpollina asked me to make in a DM conversation (and which @kitazy52 and @babo989 indicated they were fine with in the [2024-05-09 software meeting](https://docs.google.com/document/d/1Iba0_9yNFEDdp1Qy8IYlLP43Ga0DnDr3CdavWV0QGZY/edit#heading=h.g8wbfh85gs3a)). At @tpollina's request, I am implementing this change as a temporary action which will be revisited in a discussion and formal decision in a future software meeting (hopefully the 2024-05-16 software meeting), as the initial addition of this FAQ question in #274 was not discussed/reviewed at the time, and it has caused issues for FairScope.

This PR supercedes #408, which I accidentally created incorrectly.