### PR TITLE
Deploy `machine-name` via Forklift with pallet-standard rather than the OS setup scripts

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.mi
 for all releases after `v2.3.0`.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Changed
+
+- (System: administration) The `machine-name` binary is no longer provided by the OS setup scripts, but instead is provided by Forklift for upgradeability (by upgrading the pallet applied to the Raspberry Pi) & removeability/replaceability (by switching to a different pallet which provides a different version of - or does not provide - the `machine-name`).
+
 ## v2024.0.0-alpha.2 - 2024-04-25
 
 ### Added

--- a/software/distro/setup/base-os/forklift/install.sh
+++ b/software/distro/setup/base-os/forklift/install.sh
@@ -9,9 +9,9 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Install Forklift
 
-forklift_version="0.7.0"
+forklift_version="0.7.2-alpha.5"
 pallet_path="github.com/PlanktoScope/pallet-standard"
-pallet_version="v2024.0.0-alpha.2"
+pallet_version="feature/machine-name-binary"
 
 arch="$(dpkg --print-architecture | sed -e 's/armhf/arm/' -e 's/aarch64/arm64/')"
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_${arch}.tar.gz" \

--- a/software/distro/setup/base-os/forklift/install.sh
+++ b/software/distro/setup/base-os/forklift/install.sh
@@ -11,7 +11,7 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 forklift_version="0.7.2-alpha.5"
 pallet_path="github.com/PlanktoScope/pallet-standard"
-pallet_version="feature/machine-name-binary"
+pallet_version="3cf8510"
 
 arch="$(dpkg --print-architecture | sed -e 's/armhf/arm/' -e 's/aarch64/arm64/')"
 curl -L "https://github.com/PlanktoScope/forklift/releases/download/v$forklift_version/forklift_${forklift_version}_linux_${arch}.tar.gz" \

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -43,13 +43,8 @@ sudo usermod -aG docker $USER
 sudo apt-get install -y --no-install-recommends cockpit
 # TODO: after we switch to NetworkManager, add cockpit-networkmanager
 
-# Install tool to generate machine names based on serial numbers
-machinename_version="0.1.3"
-arch="$(dpkg --print-architecture | sed -e 's/armhf/arm/' -e 's/aarch64/arm64/')"
-curl -L "https://github.com/PlanktoScope/machine-name/releases/download/v$machinename_version/machine-name_${machinename_version}_linux_${arch}.tar.gz" \
-  | sudo tar -xz -C /usr/bin/ machine-name
-sudo mv /usr/bin/machine-name "/usr/bin/machine-name-${machinename_version}"
-sudo ln -s "machine-name-${machinename_version}" /usr/bin/machine-name
+# Prepare tool to generate machine names based on serial numbers
+# Note: the tool itself is deployed/managed by Forklift.
 # TODO: remove this by updating the Node-RED frontend and Python backend:
 # Add a symlink at /var/lib/planktoscope/machine-name for backwards-compatibility with the Node-RED
 # frontend and Python backend, which are not yet updated to check /run/machine-name instead:


### PR DESCRIPTION
This PR updates the PlanktoScope OS setup scripts to have Forklift (with the `github.com/PlanktoScope/pallet-standard` pallet) deploy the `machine-name` binary, instead of having the OS setup scripts download the binary.

This PR is associated with https://github.com/PlanktoScope/device-pkgs/pull/11 and https://github.com/PlanktoScope/pallet-standard/pull/12.