### PR TITLE
Try to fix installer versioning in CI OS builds outside PRs

### DIFF
--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -109,7 +109,9 @@ jobs:
         run: |
           if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
             printf "ACTUAL_SHA=%.7s" "${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-          elif [ ${{ env.PUSH_IMAGE }} == "true" ]; then
+          else
+            # Note: we want to have a SHA to check out even in merge queues, so we always fall back
+            # to a SHA even if it's a fictional SHA detached from any branches:
             printf "ACTUAL_SHA=%.7s" "${{ github.sha }}" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
This PR follows up on #416 by trying to fix CI OS builds in the merge queue (which currently all fail, as in https://github.com/PlanktoScope/PlanktoScope/commit/64120a1eb924f2260850d3eb88b558e921fd13f8).