### PR TITLE
Pin initial pallet for use in factory-reset process

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -9,6 +9,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Added
+
+- (System: administration) The Forklift pallet provided by default as the SD card image is now named (and pinned as) the `factory-reset` staged pallet bundle.
+
 ### Changed
 
 - (Release) SD card images are now released with xz compression (as `.img.xz` files) rather than gzip compression (as `.img.gz` files).

--- a/software/distro/setup/base-os/forklift/install.sh
+++ b/software/distro/setup/base-os/forklift/install.sh
@@ -42,7 +42,7 @@ fi
 pallet_path="$(cat "$config_files_root/forklift-pallet")"
 pallet_version="$(cat "$config_files_root/forklift-pallet-version")"
 forklift --stage-store /var/lib/forklift/stages plt switch --no-cache-img $pallet_path@$pallet_version
-forklift stage add-bundle-name factory-reset next
+forklift --stage-store /var/lib/forklift/stages stage add-bundle-name factory-reset next
 sudo systemctl mask forklift-apply.service # we'll re-enable it after finishing setup in the VM
 
 # Pre-download container images without Docker

--- a/software/distro/setup/base-os/forklift/install.sh
+++ b/software/distro/setup/base-os/forklift/install.sh
@@ -42,6 +42,7 @@ fi
 pallet_path="$(cat "$config_files_root/forklift-pallet")"
 pallet_version="$(cat "$config_files_root/forklift-pallet-version")"
 forklift --stage-store /var/lib/forklift/stages plt switch --no-cache-img $pallet_path@$pallet_version
+forklift stage add-bundle-name factory-reset next
 sudo systemctl mask forklift-apply.service # we'll re-enable it after finishing setup in the VM
 
 # Pre-download container images without Docker


### PR DESCRIPTION
This PR modifies the OS setup scripts so that the pallet included in the default SD card image is named and pinned so that it is easy to reset to, using the command `forklift stage set-next factory-reset`.