### PR TITLE
Move v2.6 default hardware version to a FairScope-specific OS image

### DIFF
--- a/.github/workflows/build-os-bullseye-fairscope.yml
+++ b/.github/workflows/build-os-bullseye-fairscope.yml
@@ -1,0 +1,47 @@
+---
+name: build-os-bullseye
+on:
+  push:
+    branches:
+      - 'master'
+      - 'software/beta'
+      - 'software/stable'
+    tags:
+      - 'software/v*'
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: 'Git ref (optional)'
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - fairscope-latest
+        arch:
+          - arm64
+        base_variant_name:
+          - lite
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/build-os.yml
+    secrets: inherit
+    with:
+      name: planktoscope
+      base_release_name: bullseye
+      base_image_variant: ${{ matrix.base_variant_name }}
+      base_release_date: 2024-03-12
+      arch: ${{ matrix.arch }}
+      variant: ${{ matrix.variant }}

--- a/.github/workflows/build-os-bullseye-fairscope.yml
+++ b/.github/workflows/build-os-bullseye-fairscope.yml
@@ -1,5 +1,5 @@
 ---
-name: build-os-bullseye
+name: build-os-bullseye-fairscope
 on:
   push:
     branches:

--- a/documentation/docs/setup/software/index.md
+++ b/documentation/docs/setup/software/index.md
@@ -30,11 +30,13 @@ PlanktoScope OS versions are independent of hardware versions, and (starting in 
 
 Currently, each version of the PlanktoScope OS is provided as two SD card images, corresponding to the two different hardware configurations supported by the PlanktoScope software:
 
-- `adafruithat`: this configuration of the PlanktoScope OS is compatible with v2.1 of the PlanktoScope hardware, which uses the Adafruit Stepper Motor HAT.
+- `adafruithat`: this configuration of the PlanktoScope OS is compatible with v2.1 of the PlanktoScope hardware, which uses the Adafruit Stepper Motor HAT. The default configuration files are for hardware v2.1, but you can select other hardware versions in the [post-installation configuration](config.md) process.
 
-- `planktoscopehat`: this configuration of the PlanktoScope OS is compatible with all versions of the PlanktoScope hardware starting with hardware v2.3; those hardware versions use a custom HAT. Note that in software versions v2.3 and v2023.9.0, the word `pscopehat` was used instead of `planktoscopehat`.
+- `planktoscopehat`: this configuration of the PlanktoScope OS is compatible with all versions of the PlanktoScope hardware starting with hardware v2.3; those hardware versions use a custom HAT. Note that in software versions v2.3 and v2023.9.0, the word `pscopehat` was used instead of `planktoscopehat`. The default configuration files are for hardware v2.5, but you can select other hardware versions in the [post-installation configuration](config.md) process.
 
-If you have a v2.1 PlanktoScope, you should probably use an `adafruithat` SD card image; if you have a PlanktoScope from FairScope or any hardware version after v2.3, you should probably use the `planktoscopehat` SD card image.
+- `fairscope-latest`: this configuration of the PlanktoScope OS is identical to the `planktoscopehat`, but it also changes the default configuration files to be for hardware version v2.6 instead of hardware version 2.5.
+
+If you have a PlanktoScope from FairScope, you should probably use the `fairscope-latest` SD card image; otherwise, if you have a non-FairScope PlanktoScope with hardware version v2.3 or later, you should probably use the `planktoscopehat` SD card image; otherwise, if you have a v2.1 PlanktoScope, you should probably use an `adafruithat` SD card image.
 
 ## Installation
 

--- a/documentation/docs/setup/software/standard-install.md
+++ b/documentation/docs/setup/software/standard-install.md
@@ -19,11 +19,7 @@ In order to complete this step, you will need all of the following:
 
 For ease of setup, we provide an SD card image file with the PlanktoScope OS. You can download it from the latest software release on the [releases page](https://github.com/PlanktoScope/PlanktoScope/releases?q=prerelease%3Afalse+draft%3Afalse&expanded=true) for the PlanktoScope project on GitHub.
 
-<<<<<<< feature/default-config-fairscope
-Each released version of the PlanktoScope OS has downloadable SD card images under the "Assets" dropdown. Depending on whether your PlanktoScope is from FairScope and on whether it uses an Adafruit Stepper HAT or the PlanktoScope HAT, you should download the corresponding `.img.gz` file.
-=======
-Each released version of the PlanktoScope OS has downloadable SD card images under the "Assets" dropdown. Depending on whether your PlanktoScope uses an Adafruit Stepper HAT or the PlanktoScope HAT, you should download the corresponding `.img.xz` file. If you purchased a PlanktoScope or PlanktoScope kit from FairScope, it probably uses the PlanktoScope HAT.
->>>>>>> master
+Each released version of the PlanktoScope OS has downloadable SD card images under the "Assets" dropdown. Depending on whether your PlanktoScope is from FairScope and on whether it uses an Adafruit Stepper HAT or the PlanktoScope HAT, you should download the corresponding `.img.xz` file.
 
 ### Write the image to the SD card
 

--- a/documentation/docs/setup/software/standard-install.md
+++ b/documentation/docs/setup/software/standard-install.md
@@ -19,7 +19,7 @@ In order to complete this step, you will need all of the following:
 
 For ease of setup, we provide an SD card image file with the PlanktoScope OS. You can download it from the latest software release on the [releases page](https://github.com/PlanktoScope/PlanktoScope/releases?q=prerelease%3Afalse+draft%3Afalse&expanded=true) for the PlanktoScope project on GitHub.
 
-Each released version of the PlanktoScope OS has downloadable SD card images under the "Assets" dropdown. Depending on whether your PlanktoScope uses an Adafruit Stepper HAT or the PlanktoScope HAT, you should download the corresponding `.img.gz` file. If you purchased a PlanktoScope or PlanktoScope kit from FairScope, it probably uses the PlanktoScope HAT.
+Each released version of the PlanktoScope OS has downloadable SD card images under the "Assets" dropdown. Depending on whether your PlanktoScope is from FairScope and on whether it uses an Adafruit Stepper HAT or the PlanktoScope HAT, you should download the corresponding `.img.gz` file.
 
 ### Write the image to the SD card
 

--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -11,10 +11,12 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ### Added
 
+- (Release) A `fairscope-latest` SD card image is now provided which is identical to the `planktoscopehat` SD card image, except that its default settings configuration file is for the v2.6 PlanktoScope hardware rather than the v2.5 PlanktoScope hardware.
 - (System: administration) The Forklift pallet provided by default as the SD card image is now named (and pinned as) the `factory-reset` staged pallet bundle.
 
 ### Changed
 
+- (Breaking change; Application: GUI) The default settings configuration file for the `planktoscopehat` SD card image has been reverted to be for the v2.5 PlanktoScope hardware (reverting a change made for v2024.0.0-alpha.2); in v2024.0.0-alpha.2, it was for the v2.6 hardware, while in previous versions it was still for the v2.5 hardware.
 - (Release) SD card images are now released with xz compression (as `.img.xz` files) rather than gzip compression (as `.img.gz` files).
 
 ### Removed

--- a/software/distro/setup/planktoscope-app-env/node-red-frontend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/node-red-frontend/install.sh
@@ -7,11 +7,19 @@ distro_setup_files_root=$(dirname $(dirname $config_files_root))
 repo_root=$(dirname $(dirname $(dirname $distro_setup_files_root)))
 
 # Get command-line args
-hardware_type="$1" # should be either adafruithat or planktoscopehat
-if [ $hardware_type = "segmenter-only" ]; then
-  echo "Warning: setting up adafruithat version of Node-RED dashboard for hardware type: $hardware_type"
-  hardware_type=adafruithat
-fi
+hardware_type="$1" # should be either adafruithat, planktoscopehat, fairscope-latest, or segmenter-only
+default_config="$hardware_type-latest"
+case "$hardware_type" in
+  "fairscope-latest")
+    hardware_type="planktoscopehat"
+    default_config="fairscope-latest"
+    ;;
+  "segmenter-only")
+    # FIXME: instead set up the segmenter-only version of the Node-RED dashboard!
+    echo "Warning: setting up adafruithat version of Node-RED dashboard for hardware type: $hardware_type"
+    hardware_type=adafruithat
+    ;;
+esac
 
 # Install dependencies
 # smbus is needed by some python3 nodes in the Node-RED dashboard for the Adafruit HAT.
@@ -35,7 +43,7 @@ mkdir -p $HOME/.node-red
 cp "$repo_root/software/node-red-dashboard/flows/$hardware_type.json" \
   $HOME/.node-red/flows.json
 mkdir -p $HOME/PlanktoScope
-cp "$repo_root/software/node-red-dashboard/default-configs/$hardware_type-latest.config.json" \
+cp "$repo_root/software/node-red-dashboard/default-configs/$default_config.config.json" \
   $HOME/PlanktoScope/config.json
 
 # Copy required dependencies with hard-coded paths in the Node-RED dashboard

--- a/software/distro/setup/planktoscope-app-env/node-red-frontend/install.sh
+++ b/software/distro/setup/planktoscope-app-env/node-red-frontend/install.sh
@@ -18,6 +18,7 @@ case "$hardware_type" in
     # FIXME: instead set up the segmenter-only version of the Node-RED dashboard!
     echo "Warning: setting up adafruithat version of Node-RED dashboard for hardware type: $hardware_type"
     hardware_type=adafruithat
+    default_config="adafruithat-latest"
     ;;
 esac
 

--- a/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
@@ -8,7 +8,14 @@ distro_setup_files_root=$(dirname $(dirname $config_files_root))
 repo_root=$(dirname $(dirname $(dirname $distro_setup_files_root)))
 
 # Get command-line args
-hardware_type="$1" # should be either adafruithat or planktoscopehat
+hardware_type="$1" # should be either adafruithat, planktoscopehat, or fairscope-latest
+default_config="$hardware_type-latest"
+case "$hardware_type" in
+  "fairscope-latest")
+    hardware_type="planktoscopehat"
+    default_config="fairscope-latest"
+    ;;
+esac
 
 ## Install basic Python tooling
 sudo apt-get install -y -o Dpkg::Progress-Fancy=0 \
@@ -34,7 +41,7 @@ $POETRY_VENV/bin/pip install --progress-bar off poetry==1.7.1
 
 # Download device-backend monorepo
 backend_repo="github.com/PlanktoScope/device-backend"
-backend_version="v2024.0.0-beta.0" # this should be either a version tag, branch name, or commit hash
+backend_version="fix/revert-default-planktoscopehat-config" # this should be either a version tag, branch name, or commit hash
 git clone "https://$backend_repo" $HOME/device-backend --no-checkout --filter=blob:none
 git -C $HOME/device-backend checkout --quiet $backend_version
 
@@ -60,7 +67,7 @@ sudo -E mkdir -p $HOME/device-backend-logs/control
 # Select the enabled hardware controller
 mkdir -p $HOME/PlanktoScope
 sudo systemctl enable "planktoscope-org.device-backend.controller-$hardware_type.service"
-cp "$HOME/device-backend/default-configs/$hardware_type-latest.hardware.json" \
+cp "$HOME/device-backend/default-configs/$default_config.hardware.json" \
   $HOME/PlanktoScope/hardware.json
 
 # Copy required dependencies with hard-coded paths in the hardware controller

--- a/software/distro/setup/planktoscope-app-env/setup.sh
+++ b/software/distro/setup/planktoscope-app-env/setup.sh
@@ -11,7 +11,7 @@ build_scripts_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Get command-line args
 
-hardware_type="$1" # should be either adafruithat, planktoscopehat, or segmenter-only
+hardware_type="$1" # should be either adafruithat, planktoscopehat, fairscope-latest, or segmenter-only
 
 # Set up pretty error printing
 

--- a/software/distro/setup/setup-unbooted.sh
+++ b/software/distro/setup/setup-unbooted.sh
@@ -9,7 +9,7 @@ setup_scripts_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Get command-line args
 
-hardware_type="$1" # should be either none, adafruithat, planktoscopehat, or segmenter-only
+hardware_type="$1" # should be either none, adafruithat, planktoscopehat, fairscope-latest, or segmenter-only
 
 # Set up pretty error printing
 

--- a/software/distro/setup/setup.sh
+++ b/software/distro/setup/setup.sh
@@ -11,7 +11,7 @@ setup_scripts_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Get command-line args
 
-hardware_type="$1" # should be either none, adafruithat, planktoscopehat, or segmenter-only
+hardware_type="$1" # should be either none, adafruithat, planktoscopehat, fairscope-latest, or segmenter-only
 
 # Run sub-scripts
 

--- a/software/node-red-dashboard/default-configs/fairscope-latest.config.json
+++ b/software/node-red-dashboard/default-configs/fairscope-latest.config.json
@@ -6,7 +6,7 @@
     "sample_sampling_gear": "net",
     "sample_gear_net_opening": 40,
     "acq_id": 1,
-    "acq_instrument": "PlanktoScope v2.5",
+    "acq_instrument": "PlanktoScope v2.6",
     "acq_celltype": 300,
     "acq_minimum_mesh": 10,
     "acq_maximum_mesh": 200,


### PR DESCRIPTION
This PR (along with https://github.com/PlanktoScope/device-backend/pull/38) is part of a prototype for a discussion in the [2024-06-13 software meeting](https://docs.google.com/document/d/1yqRMceF52-kezI2drtvw3Zbv9zkgCo27n7X2q2vmAeI/edit#heading=h.8qcosaymfqo0) about pulling back the default hardware version for the `planktoscopehat` build of the PlanktoScope OS from v2.6 back to v2.5 (reverting a change made in #385) and instead using v2.6 as the default hardware version for a FairScope-specific build of the Planktoscope OS.

Note: if this PR is combined with #432, then the hardware version in the `planktoscopehat-latest.config.json` file should be set to `null` (as done by PR #432) instead of `PlanktoScope v2.5` (as done by this PR).