### PR TITLE
Try to fix regression in starting hardware controller

### DIFF
--- a/software/distro/setup/planktoscope-app-env/cleanup.sh
+++ b/software/distro/setup/planktoscope-app-env/cleanup.sh
@@ -13,7 +13,6 @@ if [ -f $POETRY_VENV/bin/poetry ]; then
   BACKEND_CONTROLLER=$HOME/device-backend/control
   $POETRY_VENV/bin/poetry --no-interaction --directory $BACKEND_CONTROLLER cache clear _default_cache --all
   $POETRY_VENV/bin/poetry --no-interaction --directory $BACKEND_CONTROLLER cache clear piwheels --all
-  sudo rm -rf $HOME/.cache/pypoetry
 fi
 
 # Remove history files


### PR DESCRIPTION
This PR reverts a change made in #428 to also delete `~/.cache/pypoetry`, in an attempt to fix a recently-discovered regression (discovered in #430) in which the Python hardware controller fails to start with the following error which should never occur:

```
ModuleNotFoundError: No module named 'loguru'
```