### PR TITLE
Fix OS builds on PRs from external fork repos

### DIFF
--- a/.github/workflows/build-os-bookworm-dx.yml
+++ b/.github/workflows/build-os-bookworm-dx.yml
@@ -15,7 +15,7 @@ on:
     paths:
       - 'software/**'
       - '.github/workflows/build-os*.yml'
-  merge_group:
+  #merge_group:
   workflow_dispatch:
     inputs:
       git-ref:

--- a/.github/workflows/build-os-bullseye-dx.yml
+++ b/.github/workflows/build-os-bullseye-dx.yml
@@ -15,7 +15,7 @@ on:
     paths:
       - 'software/**'
       - '.github/workflows/build-os*.yml'
-  merge_group:
+  #merge_group:
   workflow_dispatch:
     inputs:
       git-ref:

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -139,6 +139,7 @@ jobs:
             # PR-triggered workflow runs have a merge commit which is detached from existing
             # branches and messes up pseudoversion determination, so instead we check out the
             # actual commit (and fetch all tags so we can determine a pseudoversion string):
+            git -C /run/os-setup config remote.origin.url "https://$REPO"
             git -C /run/os-setup config extensions.partialClone "$(git config --get remote.origin.url)"
             git -C /run/os-setup fetch --tags --filter=blob:none
             git -C /run/os-setup checkout "$VERSION_QUERY"

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -128,15 +128,14 @@ jobs:
             # chown is needed to suppress a git error about dubious repo ownership:
             sudo chown -R $USER "/run/os-setup"
 
-            # TODO: remove this troubleshooting code:
             set -x
-
             if [ -n "${{ github.event.pull_request.head.repo.full_name }}" ]; then
               REPO="github.com/${{ github.event.pull_request.head.repo.full_name }}"
             else
               REPO="github.com/${{ github.repository }}"
             fi
             VERSION_QUERY="${{ env.ACTUAL_SHA }}"
+            cat /run/os-setup/.git/config
             # PR-triggered workflow runs have a merge commit which is detached from existing
             # branches and messes up pseudoversion determination, so instead we check out the
             # actual commit (and fetch all tags so we can determine a pseudoversion string):

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -135,7 +135,6 @@ jobs:
               REPO="github.com/${{ github.repository }}"
             fi
             VERSION_QUERY="${{ env.ACTUAL_SHA }}"
-            cat /run/os-setup/.git/config
             # PR-triggered workflow runs have a merge commit which is detached from existing
             # branches and messes up pseudoversion determination, so instead we check out the
             # actual commit (and fetch all tags so we can determine a pseudoversion string):

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -128,6 +128,9 @@ jobs:
             # chown is needed to suppress a git error about dubious repo ownership:
             sudo chown -R $USER "/run/os-setup"
 
+            # TODO: remove this troubleshooting code:
+            set -x
+
             if [ -n "${{ github.event.pull_request.head.repo.full_name }}" ]; then
               REPO="github.com/${{ github.event.pull_request.head.repo.full_name }}"
             else

--- a/software/distro/setup/base-os/forklift/install.sh
+++ b/software/distro/setup/base-os/forklift/install.sh
@@ -13,6 +13,7 @@ config_files_root=$(dirname $(realpath $BASH_SOURCE))
 # Prepare most of the necessary systemd units:
 sudo cp $config_files_root/usr/lib/systemd/system/* /usr/lib/systemd/system/
 sudo cp $config_files_root/usr/lib/systemd/system-preset/* /usr/lib/systemd/system-preset/
+sudo systemctl unmask forklift-apply.service # if it was masked, we must unmask it to apply preset
 sudo systemctl preset forklift-apply.service
 # Set up read-write filesystem overlays with forklift-managed layers for /etc and /usr
 # (see https://docs.kernel.org/filesystems/overlayfs.html):
@@ -71,7 +72,7 @@ echo "Preparing to load pre-downloaded container images..."
 sudo $tmp_bin/ctr --version
 # We load images with containerd instead of Docker so that we can do it without booting into a QEMU
 # VM (warning: Docker needs to be configured to use containerd for image storage!):
-if ! systemctl status containerd.service && ! sudo systemctl start containerd.service; then
+if ! systemctl --no-pager status containerd.service && ! sudo systemctl start containerd.service; then
   # We should only reach this if we're running setup in an unbooted container:
   echo "containerd.service couldn't be started; will try to start containerd directly..."
   sudo /usr/bin/containerd &

--- a/software/distro/setup/base-os/forklift/precache-image.sh
+++ b/software/distro/setup/base-os/forklift/precache-image.sh
@@ -23,7 +23,7 @@ echo "Downloading $image to $precached_image..."
 if ! $crane --platform "$platform" pull --format legacy "$image" "$precached_image"
 then
   echo "Encountered error, trying one more time to download $image..."
-  rm -f "$precache_image" || sudo rm -f "$precached_image"
+  rm -f "$precached_image" || sudo rm -f "$precached_image"
   $crane --platform "$platform" pull --format legacy "$image" "$precached_image"
 fi
 echo "Finished downloading $image!"

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -19,5 +19,5 @@ sudo apt-get install -y -o Dpkg::Progress-Fancy=0 \
 # Add a symlink at /var/lib/planktoscope/machine-name for backwards-compatibility with the Node-RED
 # frontend and Python backend, which are not yet updated to check /run/machine-name instead:
 sudo mkdir -p /var/lib/planktoscope
-sudo rm /var/lib/planktoscope/machine-name
+sudo rm -f /var/lib/planktoscope/machine-name
 sudo ln -s /run/machine-name /var/lib/planktoscope/machine-name

--- a/software/distro/setup/base-os/tools/install.sh
+++ b/software/distro/setup/base-os/tools/install.sh
@@ -19,4 +19,5 @@ sudo apt-get install -y -o Dpkg::Progress-Fancy=0 \
 # Add a symlink at /var/lib/planktoscope/machine-name for backwards-compatibility with the Node-RED
 # frontend and Python backend, which are not yet updated to check /run/machine-name instead:
 sudo mkdir -p /var/lib/planktoscope
+sudo rm /var/lib/planktoscope/machine-name
 sudo ln -s /run/machine-name /var/lib/planktoscope/machine-name


### PR DESCRIPTION
This PR attempts to fix the GitHub Actions workflows for building OS images so that they will work correctly on PRs opened from external forks of this repo (e.g. as in #402).