### PR TITLE
Add an automatic timeout to the QEMU VM setup step

### DIFF
--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -250,6 +250,7 @@ jobs:
       # is much faster than a QEMU VM for downloading files.
       - name: Run base OS setup scripts in an unbooted container
         uses: ethanjli/pinspawn-action@v0.1.4
+        timeout-minutes: 60
         with:
           image: ${{ steps.expand-image.outputs.destination }}
           user: ${{ env.SETUP_USER }}

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -250,7 +250,7 @@ jobs:
       # is much faster than a QEMU VM for downloading files.
       - name: Run base OS setup scripts in an unbooted container
         uses: ethanjli/pinspawn-action@v0.1.4
-        timeout-minutes: 60
+        timeout-minutes: 30
         with:
           image: ${{ steps.expand-image.outputs.destination }}
           user: ${{ env.SETUP_USER }}

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -38,6 +38,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    timeout-minutes: 90
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action


### PR DESCRIPTION
This PR attempts to reduce the need to manually monitor flaky GitHub Actions workflows for building OS images, by adding timeouts to the workflow.