### PR TITLE
Add CI workflows to fast-forward release branches upon tag push

### DIFF
--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -78,6 +78,9 @@ jobs:
         with:
           docker-images: false
           swap-storage: false
+          # removing these packages involves running `apt`, which is relatively slow:
+          dotnet: false
+          large-packages: false
 
       # GET BASE IMAGE
 

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -154,9 +154,9 @@ jobs:
               "github.com/${{ env.REPO }}" "$ACTUAL_SHA" "hash" \
               "${{ inputs.variant }}" "/run/os-setup"
             echo "installer-config.yml:"
-            cat /home/pi/.local/etc/pkscope-distro/installer-config.yml
+            cat /usr/share/planktoscope/installer-config.yml
             echo "installer-versioning.yml:"
-            cat /home/pi/.local/etc/pkscope-distro/installer-versioning.yml
+            cat /usr/share/planktoscope/installer-versioning.yml
 
       # If we don't do this, then the post-job cleanup for the actions/checkout step will emit a
       # warning:

--- a/.github/workflows/release-channel-documentation-beta.yml
+++ b/.github/workflows/release-channel-documentation-beta.yml
@@ -1,0 +1,26 @@
+---
+name: release-channel-documentation-beta
+on:
+  push:
+    tags:
+      - 'documentation/v[0-9]+.[0-9]+.[0-9]+-beta.*'
+
+jobs:
+  ff-branch-documentation-beta:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: |
+          git checkout documentation/beta
+          git merge --ff-only ${{ github.ref_name }}
+
+      - uses: ad-m/github-push-action@v0.8.0
+        with:
+          branch: documentation/beta

--- a/.github/workflows/release-channel-documentation-stable.yml
+++ b/.github/workflows/release-channel-documentation-stable.yml
@@ -1,0 +1,45 @@
+---
+name: release-channel-documentation-stable
+on:
+  push:
+    tags:
+      - 'documentation/v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  ff-branch-documentation-beta:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: |
+          git checkout documentation/beta
+          git merge --ff-only ${{ github.ref_name }}
+
+      - uses: ad-m/github-push-action@v0.8.0
+        with:
+          branch: documentation/beta
+
+  ff-branch-documentation-stable:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: |
+          git checkout documentation/stable
+          git merge --ff-only ${{ github.ref_name }}
+
+      - uses: ad-m/github-push-action@v0.8.0
+        with:
+          branch: documentation/stable

--- a/.github/workflows/release-channel-software-beta.yml
+++ b/.github/workflows/release-channel-software-beta.yml
@@ -1,0 +1,26 @@
+---
+name: release-channel-software-beta
+on:
+  push:
+    tags:
+      - 'software/v[0-9]+.[0-9]+.[0-9]+-beta.*'
+
+jobs:
+  ff-branch-software-beta:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: |
+          git checkout software/beta
+          git merge --ff-only ${{ github.ref_name }}
+
+      - uses: ad-m/github-push-action@v0.8.0
+        with:
+          branch: software/beta

--- a/.github/workflows/release-channel-software-stable.yml
+++ b/.github/workflows/release-channel-software-stable.yml
@@ -1,0 +1,45 @@
+---
+name: release-channel-software-stable
+on:
+  push:
+    tags:
+      - 'software/v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  ff-branch-software-beta:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: |
+          git checkout software/beta
+          git merge --ff-only ${{ github.ref_name }}
+
+      - uses: ad-m/github-push-action@v0.8.0
+        with:
+          branch: software/beta
+
+  ff-branch-software-stable:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: |
+          git checkout software/stable
+          git merge --ff-only ${{ github.ref_name }}
+
+      - uses: ad-m/github-push-action@v0.8.0
+        with:
+          branch: software/stable

--- a/software/distro/setup/ci-record-version.sh
+++ b/software/distro/setup/ci-record-version.sh
@@ -145,9 +145,11 @@ main() {
     info "Recording versioning information to ${versioning_dir}..."
     if [ -d "${versioning_dir}" ]; then
       warn "The ${versioning_dir} directory already exists, so it will be erased."
-      sudo rm -rf "${versioning_dir}"
+      if ! rm -rf "${versioning_dir}" 2>/dev/null; then
+        sudo rm -rf "${versioning_dir}"
+      fi
     fi
-    if ! mkdir -p "${versioning_dir}"; then
+    if ! mkdir -p "${versioning_dir}" 2>/dev/null; then
       sudo mkdir -p "${versioning_dir}"
     fi
 


### PR DESCRIPTION
This PR attempts to reduce the number of manual actions needed in the OS [release checklists](https://docs.google.com/document/d/1sm8YkgpOAcqYgUbWKi8_a7H7b4qhWxjp8GCZhSop_Wc/edit#heading=h.p2lfluslwdum), by automating steps related to fast-forwarding the `documentation/beta` and `documentation/stable` and `software/beta` and `software/stable` branches to new tags with prefix `documentation/` and `stable/` for beta pre-release tags and stable release tags.