### PR TITLE
Apply max xz compression on tag-triggered OS build workflows

### DIFF
--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -383,17 +383,7 @@ jobs:
       - name: Shrink the OS image
         uses: ethanjli/pishrink-action@v0.1.3
         env:
-          # pishrink run time vs. compression level (measured in PR 428):
-          # bullseye adafruithat lite:
-          # - xz level 6: ~10 min -> 1.4 GB
-          # - xz level 1: ~3 min -> 1.6 GB
-          # - pigz level 9: ~4 min -> 2.1 GB
-          # bullseye adafruithat desktop:
-          # - xz level 9: ~16 min -> 1.8 GB
-          # - xz level 6: ~14 min -> 1.9 GB
-          # - xz level 1: ~4 min -> 2.6 GB
-          # - pigz level 9: ~4 min -> 2.5 GB
-          PISHRINK_XZ: -T0 ${{ inputs.base_image_variant == 'lite' && '-3' || '-6' }}
+          PISHRINK_XZ: -T0 ${{ github.ref_type == 'tag' && '-9' || '-1' }}
         with:
           image: ${{ steps.expand-image.outputs.destination }}
           destination: ${{ env.OUTPUT_IMAGE_NAME }}.img


### PR DESCRIPTION
This PR adjusts the xz compression levels in the OS image build workflows to apply minimum compression (for faster CI runs) in PR-triggered and branch push-triggered workflow runs, and to apply maximum compression in tag push-triggered workflow runs (to maximize the chance of getting a compressed result which is smaller than 2.0 GiB in size, since that's GitHub's size limit for release attachments).