### PR TITLE
Try to trigger docs deployment from docs release-channel workflows

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,4 +1,4 @@
-name: Build documentation
+name: build-documentation
 
 on:
   push:

--- a/.github/workflows/documentation-deploy-beta.yml
+++ b/.github/workflows/documentation-deploy-beta.yml
@@ -1,4 +1,4 @@
-name: Deploy documentation (beta release channel)
+name: deploy-documentation/beta
 
 on:
   push:
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: documentation/beta
 
       - name: Install dependencies for mkdocs-material image-processing libraries
         run: |

--- a/.github/workflows/documentation-deploy-beta.yml
+++ b/.github/workflows/documentation-deploy-beta.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'documentation/beta'
+  workflow_call:
   workflow_dispatch:
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest

--- a/.github/workflows/documentation-deploy-edge.yml
+++ b/.github/workflows/documentation-deploy-edge.yml
@@ -1,4 +1,4 @@
-name: Deploy documentation (edge release channel)
+name: deploy-documentation/edge
 
 on:
   push:

--- a/.github/workflows/documentation-deploy-stable.yml
+++ b/.github/workflows/documentation-deploy-stable.yml
@@ -1,4 +1,4 @@
-name: Deploy documentation (stable release channel)
+name: deploy-documentation/stable
 
 on:
   push:
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: documentation/stable
 
       - name: Install dependencies for mkdocs-material image-processing libraries
         run: |

--- a/.github/workflows/documentation-deploy-stable.yml
+++ b/.github/workflows/documentation-deploy-stable.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'documentation/stable'
+  workflow_call:
   workflow_dispatch:
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest

--- a/.github/workflows/release-channel-documentation-beta.yml
+++ b/.github/workflows/release-channel-documentation-beta.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'documentation/v[0-9]+.[0-9]+.[0-9]+-beta.*'
-      # We want to advance the beta to the latest stable release, too:
+      # We want to advance the documentation/beta branch to the latest stable release, too:
       - 'documentation/v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:

--- a/.github/workflows/release-channel-documentation-beta.yml
+++ b/.github/workflows/release-channel-documentation-beta.yml
@@ -1,12 +1,14 @@
 ---
-name: release-channel-documentation-beta
+name: release-channel-documentation/beta
 on:
   push:
     tags:
       - 'documentation/v[0-9]+.[0-9]+.[0-9]+-beta.*'
+      # We want to advance the beta to the latest stable release, too:
+      - 'documentation/v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  ff-branch-documentation-beta:
+  ff-branch:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -24,3 +26,10 @@ jobs:
       - uses: ad-m/github-push-action@v0.8.0
         with:
           branch: documentation/beta
+
+  deploy-docs-site:
+    # We call this workflow manually because it doesn't appear to be triggered automatically by a
+    # push of the documentation/beta branch from the ff-branch job:
+    uses: ./.github/workflows/documentation-deploy-beta.yml
+    needs: ff-branch
+    secrets: inherit

--- a/.github/workflows/release-channel-documentation-stable.yml
+++ b/.github/workflows/release-channel-documentation-stable.yml
@@ -1,31 +1,12 @@
 ---
-name: release-channel-documentation-stable
+name: release-channel-documentation/stable
 on:
   push:
     tags:
       - 'documentation/v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  ff-branch-documentation-beta:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - run: |
-          git checkout documentation/beta
-          git merge --ff-only ${{ github.ref_name }}
-
-      - uses: ad-m/github-push-action@v0.8.0
-        with:
-          branch: documentation/beta
-
-  ff-branch-documentation-stable:
+  ff-branch:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -43,3 +24,10 @@ jobs:
       - uses: ad-m/github-push-action@v0.8.0
         with:
           branch: documentation/stable
+
+  deploy-docs-site:
+    # We call this workflow manually because it doesn't appear to be triggered automatically by a
+    # push of the documentation/stable branch from the ff-branch job:
+    uses: ./.github/workflows/documentation-deploy-stable.yml
+    needs: ff-branch
+    secrets: inherit

--- a/.github/workflows/release-channel-software-beta.yml
+++ b/.github/workflows/release-channel-software-beta.yml
@@ -1,12 +1,14 @@
 ---
-name: release-channel-software-beta
+name: release-channel-software/beta
 on:
   push:
     tags:
       - 'software/v[0-9]+.[0-9]+.[0-9]+-beta.*'
+      # We want to advance the beta branch to the latest stable release, too:
+      - 'software/v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  ff-branch-software-beta:
+  ff-branch:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/release-channel-software-stable.yml
+++ b/.github/workflows/release-channel-software-stable.yml
@@ -1,31 +1,12 @@
 ---
-name: release-channel-software-stable
+name: release-channel-software/stable
 on:
   push:
     tags:
       - 'software/v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  ff-branch-software-beta:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - run: |
-          git checkout software/beta
-          git merge --ff-only ${{ github.ref_name }}
-
-      - uses: ad-m/github-push-action@v0.8.0
-        with:
-          branch: software/beta
-
-  ff-branch-software-stable:
+  ff-branch:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR attempts to fix a regression in the triggering of deployment of the docs site to https://docs-beta.planktoscope.community and https://docs.planktoscope.community; the regression was that the triggering is no longer automatically done, probably as a result of changes made in #441.