### PR TITLE
Describe default Wi-Fi hotspot password in docs

### DIFF
--- a/documentation/docs/operation/index.md
+++ b/documentation/docs/operation/index.md
@@ -20,6 +20,8 @@ Unless you have already configured your PlanktoScope to connect to an existing W
 
 As you can see, the name of your PlanktoScope's Wi-Fi network will be of the format `pkscope-{random word}-{random word}-{random number}`. This name corresponds exactly to the serial number of the Raspberry Pi computer in your PlanktoScope, so it is a unique Wi-Fi network name; and the unique name of your machine has format `{random-word}-{random-word}-{random number}`, which is just the name of the Wi-Fi network but without the `pkscope-` prefix (e.g. `chain-list-27764`). You should connect to the Wi-Fi network specific to your PlanktoScope.
 
+Unless you have changed the password of your PlanktoScope's Wi-Fi network, the password should be `copepode`.
+
 ### Access your PlanktoScope's software
 
 Once you connect your computer to your PlanktoScope, you will need to access your PlanktoScope's software from a web browser on your computer. You should try opening the following URLs in your web browser (try opening them in the following order, and just use the first one which works):

--- a/documentation/docs/setup/software/nonstandard-install.md
+++ b/documentation/docs/setup/software/nonstandard-install.md
@@ -127,7 +127,9 @@ sudo reboot now
 
 This step is necessary to finish the PlanktoScope software setup process.
 
-Afterwards, your PlanktoScope's Raspberry Pi will either connect to a Wi-Fi network (if you had previously configured it to connect to a Wi-Fi network) or make a new isolated Wi-Fi network whose name starts with the word `pkscope` followed by the unique randomly-generated name of your PlanktoScope. If you connect another device (e.g. a phone or computer) directly to the PlanktoScope's Raspberry Pi over its isolated Wi-Fi network or over an Ethernet cable, then you can open a web browser on the device to access the PlanktoScope's graphical user interface at one of the following URLs (try them in the following order, and just use the first one which works):
+Afterwards, your PlanktoScope's Raspberry Pi will either connect to a Wi-Fi network (if you had previously configured it to connect to a Wi-Fi network) or make a new isolated Wi-Fi network whose name starts with the word `pkscope` followed by the unique randomly-generated name of your PlanktoScope, and whose password is `copepode`.
+
+If you connect another device (e.g. a phone or computer) directly to the PlanktoScope's Raspberry Pi over its isolated Wi-Fi network or over an Ethernet cable, then you can open a web browser on the device to access the PlanktoScope's graphical user interface at one of the following URLs (try them in the following order, and just use the first one which works):
 
 - <http://planktoscope.local> (this should work unless you're on a device and web browser without mDNS support; notably, older versions of Android do not have mDNS support)
 - <http://pkscope.local> (this should work unless you're on a device and web browser without mDNS support; notably, older versions of Android do not have mDNS support)

--- a/documentation/docs/setup/software/standard-install.md
+++ b/documentation/docs/setup/software/standard-install.md
@@ -40,7 +40,7 @@ Insert the microSD card into the Raspberry Pi computer installed in your Plankto
 
 ## Connect to the PlanktoScope
 
-Power on your PlanktoScope, and wait for it to start up. Note that it may take a few minutes to start up. Once it has finished starting up, it should create a new isolated Wi-Fi network whose name starts with the word `pkscope` followed by the unique randomly-generated name of your PlanktoScope.
+Power on your PlanktoScope, and wait for it to start up. Note that it may take a few minutes to start up. Once it has finished starting up, it should create a new isolated Wi-Fi network whose name starts with the word `pkscope` followed by the unique randomly-generated name of your PlanktoScope. The password of this Wi-Fi network is `copepode`.
 
 Note that you will not be able to access the PlanktoScope's graphical user interface by plugging in a display to the Raspberry Pi. This is because the SD card image we provide does not include a graphical desktop or web browser, in order to keep the SD card image file smaller and to keep the PlanktoScope's Raspberry Pi running more efficiently. Instead, you will need to connect another device (e.g. a phone or a computer) directly to the PlanktoScope's Raspberry Pi, either over its isolated Wi-Fi network or over an Ethernet cable.
 


### PR DESCRIPTION
This PR adds information to the docs site about the default password (`copepode`) for the PlanktoScope's Wi-Fi hotspot - previously that information was missing in the docs site, which led to some FairScope customers being confused about what the password should be. They had assumed that the Wi-Fi network name should be the password.