### PR TITLE
Change default ISO to 150

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -13,6 +13,14 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 - (System: administration) Added a Forklift-deployed script `/usr/libexec/prepare-custom-image` (which must be invoked with `sudo`) to reset machine-specific files and re-enable partition resizing and shut down the Raspberry Pi, in order to automate common tasks needed for making a custom SD card image from a booted Raspberry Pi running the PlanktoScope OS. Support for this script should be considered experimental - this was mainly added as a workaround to a developer-experience regression introduced after v2023.9.0, in which an additional step is now needed after making an SD card image from a previously-booted SD card, or else the image will result in an error message loop ("Partition #2 contains a ext4 signature") during boot and will be unable to resize the image above 8 GB. That step is now included by the added script. Creation of custom SD card images from booted PlanktoScope OS images should still be considered an experimental workflow which may experience breaking changes to the developer experience at any time.
 
+### Changed
+
+- (Application: GUI) Changed the default ISO value from 100 to 150.
+
+### Fixed
+
+- (Application: backend) Changed the hardware controller's libcamera-based camera controller to initialize its default image gain based on camera sensor type in order to match the GUI's default ISO value of 150, instead of initializing default image gain to 1.0 regardless of camera sensor type.
+
 ## v2024.0.0-beta.1 - 2024-06-24
 
 ### Added

--- a/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
@@ -41,7 +41,7 @@ python3 -m venv "$POETRY_VENV"
 
 # Download device-backend monorepo
 backend_repo="github.com/PlanktoScope/device-backend"
-backend_version="dce93ab" # this should be either a version tag, branch name, or commit hash
+backend_version="aceef97" # this should be either a version tag, branch name, or commit hash
 git clone "https://$backend_repo" "$HOME/device-backend" --no-checkout --filter=blob:none
 git -C "$HOME/device-backend" checkout --quiet $backend_version
 

--- a/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
@@ -41,7 +41,7 @@ python3 -m venv "$POETRY_VENV"
 
 # Download device-backend monorepo
 backend_repo="github.com/PlanktoScope/device-backend"
-backend_version="aceef97" # this should be either a version tag, branch name, or commit hash
+backend_version="b2e1f92" # this should be either a version tag, branch name, or commit hash
 git clone "https://$backend_repo" "$HOME/device-backend" --no-checkout --filter=blob:none
 git -C "$HOME/device-backend" checkout --quiet $backend_version
 

--- a/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
+++ b/software/distro/setup/planktoscope-app-env/python-hardware-controller/install.sh
@@ -3,9 +3,9 @@
 # logic for operating the PlanktoScope hardware.
 
 # Determine the base path for copied files
-config_files_root=$(dirname $(realpath $BASH_SOURCE))
-distro_setup_files_root=$(dirname $(dirname $config_files_root))
-repo_root=$(dirname $(dirname $(dirname $distro_setup_files_root)))
+config_files_root="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+distro_setup_files_root="$(dirname "$(dirname "$config_files_root")")"
+repo_root="$(dirname "$(dirname "$(dirname "$distro_setup_files_root")")")"
 
 # Get command-line args
 hardware_type="$1" # should be either adafruithat, planktoscopehat, or fairscope-latest
@@ -23,7 +23,7 @@ sudo apt-get install -y -o Dpkg::Progress-Fancy=0 \
 
 # Suppress keyring dialogs when setting up the PlanktoScope distro on a graphical desktop
 # (see https://github.com/pypa/pip/issues/7883)
-PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
 
 # Install Poetry
 # Note: Because the poetry installation process (whether with pipx or the official installer) always
@@ -32,18 +32,18 @@ PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
 # We have had problems in the past with a version of that dependency not being available from
 # piwheels.
 POETRY_VENV=$HOME/.local/share/pypoetry/venv
-mkdir -p $POETRY_VENV
-python3 -m venv $POETRY_VENV
-$POETRY_VENV/bin/pip install --upgrade --progress-bar off \
+mkdir -p "$POETRY_VENV"
+python3 -m venv "$POETRY_VENV"
+"$POETRY_VENV/bin/pip" install --upgrade --progress-bar off \
   pip==23.3.2 setuptools==68.2.2
-$POETRY_VENV/bin/pip install --progress-bar off cryptography==41.0.5
-$POETRY_VENV/bin/pip install --progress-bar off poetry==1.7.1
+"$POETRY_VENV/bin/pip" install --progress-bar off cryptography==41.0.5
+"$POETRY_VENV/bin/pip" install --progress-bar off poetry==1.7.1
 
 # Download device-backend monorepo
 backend_repo="github.com/PlanktoScope/device-backend"
-backend_version="v2024.0.0-beta.1" # this should be either a version tag, branch name, or commit hash
-git clone "https://$backend_repo" $HOME/device-backend --no-checkout --filter=blob:none
-git -C $HOME/device-backend checkout --quiet $backend_version
+backend_version="dce93ab" # this should be either a version tag, branch name, or commit hash
+git clone "https://$backend_repo" "$HOME/device-backend" --no-checkout --filter=blob:none
+git -C "$HOME/device-backend" checkout --quiet $backend_version
 
 # Set up the hardware controllers
 # Note(ethanjli): we use picamera2 from the system for compatibility, and because dependencies are
@@ -51,9 +51,9 @@ git -C $HOME/device-backend checkout --quiet $backend_version
 # install it via poetry.
 sudo apt-get install -y --no-install-recommends -o Dpkg::Progress-Fancy=0 \
   i2c-tools libopenjp2-7 python3-picamera2
-$POETRY_VENV/bin/poetry --directory $HOME/device-backend/control config \
+"$POETRY_VENV/bin/poetry" --directory "$HOME/device-backend/control" config \
   virtualenvs.options.system-site-packages true --local
-$POETRY_VENV/bin/poetry --directory $HOME/device-backend/control install \
+"$POETRY_VENV/bin/poetry" --directory "$HOME/device-backend/control" install \
   --no-root --compile
 file="/etc/systemd/system/planktoscope-org.device-backend.controller-adafruithat.service"
 sudo cp "$config_files_root$file" "$file"
@@ -61,17 +61,17 @@ sudo cp "$config_files_root$file" "$file"
 file="/etc/systemd/system/planktoscope-org.device-backend.controller-planktoscopehat.service"
 sudo cp "$config_files_root$file" "$file"
 # FIXME: make this directory in the main.py file
-sudo -E mkdir -p $HOME/data/img
-sudo -E mkdir -p $HOME/device-backend-logs/control
+sudo -E mkdir -p "$HOME/data/img"
+sudo -E mkdir -p "$HOME/device-backend-logs/control"
 
 # Select the enabled hardware controller
-mkdir -p $HOME/PlanktoScope
+mkdir -p "$HOME/PlanktoScope"
 sudo systemctl enable "planktoscope-org.device-backend.controller-$hardware_type.service"
 cp "$HOME/device-backend/default-configs/$default_config.hardware.json" \
-  $HOME/PlanktoScope/hardware.json
+  "$HOME/PlanktoScope/hardware.json"
 
 # Copy required dependencies with hard-coded paths in the hardware controller
 # TODO: get rid of this when we remove raspimjpeg
-mkdir -p $HOME/PlanktoScope/scripts
+mkdir -p "$HOME/PlanktoScope/scripts"
 directory="scripts/raspimjpeg"
-cp -r "$repo_root/$directory" $HOME/PlanktoScope/$directory
+cp -r "$repo_root/$directory" "$HOME/PlanktoScope/$directory"

--- a/software/node-red-dashboard/flows/adafruithat.json
+++ b/software/node-red-dashboard/flows/adafruithat.json
@@ -4412,7 +4412,7 @@
         "id": "d8d006bf.2947f",
         "type": "inject",
         "z": "bccd1f23.87219",
-        "name": "Default: ISO 100",
+        "name": "Default: ISO 150",
         "props": [
             {
                 "p": "payload"
@@ -4423,7 +4423,7 @@
         "once": true,
         "onceDelay": "1",
         "topic": "",
-        "payload": "100",
+        "payload": "150",
         "payloadType": "num",
         "x": 130,
         "y": 840,

--- a/software/node-red-dashboard/flows/planktoscopehat.json
+++ b/software/node-red-dashboard/flows/planktoscopehat.json
@@ -4736,7 +4736,7 @@
         "id": "d8d006bf.2947f",
         "type": "inject",
         "z": "bccd1f23.87219",
-        "name": "Default: ISO 100",
+        "name": "Default: ISO 150",
         "props": [
             {
                 "p": "payload"
@@ -4747,7 +4747,7 @@
         "once": true,
         "onceDelay": "1",
         "topic": "",
-        "payload": "100",
+        "payload": "150",
         "payloadType": "num",
         "x": 130,
         "y": 840,


### PR DESCRIPTION
This PR integrates https://github.com/PlanktoScope/device-backend/pull/48 in order to fix for a regression reported to me (privately, in DMs) by @fabienlombard on PlanktoScope OS v2024.0.0-beta.1, in which the default ISO setting displayed on the Node-RED dashboard was inconsistent with the actual initial image gain (of 1.0, which corresponds to an ISO of ~54 on the PlanktoScope hardware v2.1's camera and an ISO of ~43 on the PlanktoScope hardware v2.3+'s camera). This PR initializes the image gain value to match a consistent ISO setting of 150, which this PR makes the default ISO setting for both the adafruithat Node-RED dashboard and the planktoscopehat Node-RED dashboard.

This fix was discussed and approved in the [2024-07-25 software meeting](https://docs.google.com/document/d/1yqRMceF52-kezI2drtvw3Zbv9zkgCo27n7X2q2vmAeI/edit#heading=h.6csyvp7b4rjc).