### PR TITLE
fixing the typo on the systemd-timesyncd.service

### DIFF
--- a/software/distro/setup/planktoscope-app-env/gps/install.sh
+++ b/software/distro/setup/planktoscope-app-env/gps/install.sh
@@ -5,6 +5,12 @@
 # Determine the base path for copied files
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
+# Use chrony instead of systemd-timesyncd (but do we really actually want to do this??):
+if ! sudo systemctl disable systemd-timesyncd.service --now; then
+  # If we're in an unbooted container, the service isn't running - so we don't need to stop it now:
+  sudo systemctl disable systemd-timesyncd.service
+fi
+
 # Install dependencies
 sudo apt-get install -y -o Dpkg::Progress-Fancy=0 \
   gpsd pps-tools chrony
@@ -23,8 +29,4 @@ fi
 file="/boot/config.txt"
 sudo bash -c "cat \"$config_files_root$file.snippet\" >> \"$file\""
 
-# Use chrony instead of systemd-timesyncd (but do we really actually want to do this??):
-if ! sudo systemctl disable systemd-timesyncd.service --now; then
-  # If we're in an unbooted container, the service isn't running - so we don't need to stop it now:
-  sudo systemctl disable systemd-timesyncd.service
-fi
+

--- a/software/distro/setup/planktoscope-app-env/gps/install.sh
+++ b/software/distro/setup/planktoscope-app-env/gps/install.sh
@@ -5,12 +5,6 @@
 # Determine the base path for copied files
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
-# Use chrony instead of systemd-timesyncd (but do we really actually want to do this??):
-# if ! sudo systemctl disable systemd-timesyncd.service --now; then
-#   # If we're in an unbooted container, the service isn't running - so we don't need to stop it now:
-#   sudo systemctl disable systemd-timesyncd.service
-# fi
-
 # Install dependencies
 sudo apt-get install -y -o Dpkg::Progress-Fancy=0 \
   gpsd pps-tools chrony

--- a/software/distro/setup/planktoscope-app-env/gps/install.sh
+++ b/software/distro/setup/planktoscope-app-env/gps/install.sh
@@ -6,10 +6,10 @@
 config_files_root=$(dirname $(realpath $BASH_SOURCE))
 
 # Use chrony instead of systemd-timesyncd (but do we really actually want to do this??):
-if ! sudo systemctl disable systemd-timesyncd.service --now; then
-  # If we're in an unbooted container, the service isn't running - so we don't need to stop it now:
-  sudo systemctl disable systemd-timesyncd.service
-fi
+# if ! sudo systemctl disable systemd-timesyncd.service --now; then
+#   # If we're in an unbooted container, the service isn't running - so we don't need to stop it now:
+#   sudo systemctl disable systemd-timesyncd.service
+# fi
 
 # Install dependencies
 sudo apt-get install -y -o Dpkg::Progress-Fancy=0 \

--- a/software/distro/setup/planktoscope-app-env/gps/install.sh
+++ b/software/distro/setup/planktoscope-app-env/gps/install.sh
@@ -26,5 +26,5 @@ sudo bash -c "cat \"$config_files_root$file.snippet\" >> \"$file\""
 # Use chrony instead of systemd-timesyncd (but do we really actually want to do this??):
 if ! sudo systemctl disable systemd-timesyncd.service --now; then
   # If we're in an unbooted container, the service isn't running - so we don't need to stop it now:
-  sudo systemctl disable systemd-timesyncd.servkce
+  sudo systemctl disable systemd-timesyncd.service
 fi


### PR DESCRIPTION
This PR resolves errors related to systemd-timesyncd when manually running the OS setup scripts on a Raspberry Pi 5. Specifically, this PR removes commands to disable the `systemd-timesyncd` service, which is uninstalled once chrony is installed - resulting in errors that there is no longer any `systemd-timesyncd` service to disable (because the service was already uninstalled by apt).