### PR TITLE
Use merge gatekeeper to avoid running slow CI workflows when not needed

### DIFF
--- a/.github/workflows/build-os-bullseye-fairscope.yml
+++ b/.github/workflows/build-os-bullseye-fairscope.yml
@@ -9,6 +9,9 @@ on:
     tags:
       - 'software/v*'
   pull_request:
+    paths:
+      - 'software/**'
+      - '.github/workflows/build-os*.yml'
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-os-bullseye-fairscope.yml
+++ b/.github/workflows/build-os-bullseye-fairscope.yml
@@ -8,6 +8,9 @@ on:
       - 'software/stable'
     tags:
       - 'software/v*'
+    paths:
+      - 'software/**'
+      - '.github/workflows/build-os*.yml'
   pull_request:
     paths:
       - 'software/**'

--- a/.github/workflows/build-os-bullseye.yml
+++ b/.github/workflows/build-os-bullseye.yml
@@ -9,6 +9,9 @@ on:
     tags:
       - 'software/v*'
   pull_request:
+    paths:
+      - 'software/**'
+      - '.github/workflows/build-os*.yml'
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-os-bullseye.yml
+++ b/.github/workflows/build-os-bullseye.yml
@@ -8,6 +8,9 @@ on:
       - 'software/stable'
     tags:
       - 'software/v*'
+    paths:
+      - 'software/**'
+      - '.github/workflows/build-os*.yml'
   pull_request:
     paths:
       - 'software/**'

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -11,6 +11,9 @@ on:
     tags:
       - 'documentation/v*'
   pull_request:
+    paths:
+      - 'documentation/**'
+      - 'hardware/**'
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -1,0 +1,30 @@
+---
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        if: github.event_name != 'merge_group'
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 3600 # 60-minute timeout, since OS build workflows may take ~40 minutes to run
+          interval: 60
+
+      - name: Run Merge Gatekeeper in Merge Queue
+        if: github.event_name == 'merge_group'
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          ref: ${{github.ref}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 3600 # 60-minute timeout, since OS build workflows may take ~40 minutes to run
+          interval: 60


### PR DESCRIPTION
This PR attempts to avoid needing to run CI checks for the hardware controller on PRs which only modify the segmenter (and vice versa), by adding https://github.com/upsidr/merge-gatekeeper and making that the only required check.