### PR TITLE
Rename "Dilution Factor" input field to "Concentration Factor"

### DIFF
--- a/software/CHANGELOG.md
+++ b/software/CHANGELOG.md
@@ -22,6 +22,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - (Application: backend) The old raspimjpeg-based imager has now been completely removed, following a deprecation in v2024.0.0-alpha.2.
 - (Application: GUI) Various elements of the Node-RED dashboard which were deprecated in v2024.0.0 and in v2024.0.0-alpha.2 have now been removed, including the old USB backup functionality.
 
+### Fixed
+
+- (Application: GUI) The Node-RED dashboard's sample page's "Dilution Factor" input field has been renamed to "Concentration Factor", which is a less misleading name for what that input field actually represents.
+
 ## v2024.0.0 - 2024-12-25
 
 ### Added

--- a/software/node-red-dashboard/flows/adafruithat.json
+++ b/software/node-red-dashboard/flows/adafruithat.json
@@ -2734,7 +2734,7 @@
         "type": "ui_text_input",
         "z": "b771c342.49603",
         "name": "sample_dilution_factor",
-        "label": "Dilution Factor",
+        "label": "Concentration Factor",
         "tooltip": "0.5 if diluted by two; 2 if concentrated by a factor 2",
         "group": "3e1ba03d.f01d8",
         "order": 13,

--- a/software/node-red-dashboard/flows/planktoscopehat.json
+++ b/software/node-red-dashboard/flows/planktoscopehat.json
@@ -2941,7 +2941,7 @@
         "type": "ui_text_input",
         "z": "b771c342.49603",
         "name": "sample_dilution_factor",
-        "label": "Dilution Factor",
+        "label": "Concentration Factor",
         "tooltip": "0.5 if diluted by two; 2 if concentrated by a factor 2",
         "group": "3e1ba03d.f01d8",
         "order": 13,


### PR DESCRIPTION
This PR implements a change requested in the [2025-01-23 software meeting](https://docs.google.com/document/d/1AN1jaIdfKChKjMnzSd3ecjRTZGOnoglBfV9LCpevMgk/edit?tab=t.0#heading=h.54f2ya6r0sza), to rename the Node-RED dashboard's "Dilution Factor" input field to something less misleading.