### PR TITLE
Try to remove piwiz from desktop images

### DIFF
--- a/software/distro/setup/planktoscope-app-env/setup.sh
+++ b/software/distro/setup/planktoscope-app-env/setup.sh
@@ -37,6 +37,14 @@ function panic {
 
 # Run sub-scripts
 
+description="disable first-boot wizards"
+report_starting "$description"
+if "$build_scripts_root/wizards/remove.sh"; then
+  report_finished "$description"
+else
+  panic "$description"
+fi
+
 description="set up Node-RED frontend"
 report_starting "$description"
 if "$build_scripts_root/node-red-frontend/install.sh" "$hardware_type"; then
@@ -77,14 +85,6 @@ fi
 description="enable CPU overclocking"
 report_starting "$description"
 if "$build_scripts_root/overclocking/config.sh"; then
-  report_finished "$description"
-else
-  panic "$description"
-fi
-
-description="disable first-boot wizards"
-report_starting "$description"
-if "$build_scripts_root/wizards/remove.sh"; then
   report_finished "$description"
 else
   panic "$description"

--- a/software/distro/setup/planktoscope-app-env/setup.sh
+++ b/software/distro/setup/planktoscope-app-env/setup.sh
@@ -7,7 +7,7 @@
 
 # Determine the base path for sub-scripts
 
-build_scripts_root=$(dirname $(realpath $BASH_SOURCE))
+build_scripts_root=$(dirname "$(realpath "$BASH_SOURCE")")
 
 # Get command-line args
 
@@ -39,20 +39,20 @@ function panic {
 
 description="set up Node-RED frontend"
 report_starting "$description"
-if $build_scripts_root/node-red-frontend/install.sh "$hardware_type" ; then
+if "$build_scripts_root/node-red-frontend/install.sh" "$hardware_type"; then
   report_finished "$description"
 else
   panic "$description"
 fi
 
-if [ $hardware_type = "segmenter-only" ]; then
+if [ "$hardware_type" = "segmenter-only" ]; then
   echo "Warning: skipping PlanktoScope hardware-specific setup because hardware type was specified as: $hardware_type"
   exit 0
 fi
 
 description="set up Python hardware controller"
 report_starting "$description"
-if $build_scripts_root/python-hardware-controller/install.sh "$hardware_type" ; then
+if "$build_scripts_root/python-hardware-controller/install.sh" "$hardware_type"; then
   report_finished "$description"
 else
   panic "$description"
@@ -60,7 +60,7 @@ fi
 
 description="configure kernel hardware drivers"
 report_starting "$description"
-if $build_scripts_root/platform-hardware/config.sh ; then
+if "$build_scripts_root/platform-hardware/config.sh"; then
   report_finished "$description"
 else
   panic "$description"
@@ -68,7 +68,7 @@ fi
 
 description="set up GPS and clock driver"
 report_starting "$description"
-if $build_scripts_root/gps/install.sh ; then
+if "$build_scripts_root/gps/install.sh"; then
   report_finished "$description"
 else
   panic "$description"
@@ -76,7 +76,15 @@ fi
 
 description="enable CPU overclocking"
 report_starting "$description"
-if $build_scripts_root/overclocking/config.sh ; then
+if "$build_scripts_root/overclocking/config.sh"; then
+  report_finished "$description"
+else
+  panic "$description"
+fi
+
+description="disable first-boot wizards"
+report_starting "$description"
+if "$build_scripts_root/wizards/remove.sh"; then
   report_finished "$description"
 else
   panic "$description"

--- a/software/distro/setup/planktoscope-app-env/wizards/etc/lightdm/lightdm.conf
+++ b/software/distro/setup/planktoscope-app-env/wizards/etc/lightdm/lightdm.conf
@@ -1,0 +1,175 @@
+#
+# General configuration
+#
+# start-default-seat = True to always start one seat if none are defined in the configuration
+# greeter-user = User to run greeter as
+# minimum-display-number = Minimum display number to use for X servers
+# minimum-vt = First VT to run displays on
+# lock-memory = True to prevent memory from being paged to disk
+# user-authority-in-system-dir = True if session authority should be in the system location
+# guest-account-script = Script to be run to setup guest account
+# logind-check-graphical = True to on start seats that are marked as graphical by logind
+# log-directory = Directory to log information to
+# run-directory = Directory to put running state in
+# cache-directory = Directory to cache to
+# sessions-directory = Directory to find sessions
+# remote-sessions-directory = Directory to find remote sessions
+# greeters-directory = Directory to find greeters
+# backup-logs = True to move add a .old suffix to old log files when opening new ones
+# dbus-service = True if LightDM provides a D-Bus service to control it
+#
+[LightDM]
+#start-default-seat=true
+#greeter-user=lightdm
+#minimum-display-number=0
+#minimum-vt=7
+#lock-memory=true
+#user-authority-in-system-dir=false
+#guest-account-script=guest-account
+#logind-check-graphical=false
+#log-directory=/var/log/lightdm
+#run-directory=/var/run/lightdm
+#cache-directory=/var/cache/lightdm
+#sessions-directory=/usr/share/lightdm/sessions:/usr/share/xsessions:/usr/share/wayland-sessions
+#remote-sessions-directory=/usr/share/lightdm/remote-sessions
+#greeters-directory=$XDG_DATA_DIRS/lightdm/greeters:$XDG_DATA_DIRS/xgreeters
+#backup-logs=true
+#dbus-service=true
+
+#
+# Seat configuration
+#
+# Seat configuration is matched against the seat name glob in the section, for example:
+# [Seat:*] matches all seats and is applied first.
+# [Seat:seat0] matches the seat named "seat0".
+# [Seat:seat-thin-client*] matches all seats that have names that start with "seat-thin-client".
+#
+# type = Seat type (local, xremote, unity)
+# pam-service = PAM service to use for login
+# pam-autologin-service = PAM service to use for autologin
+# pam-greeter-service = PAM service to use for greeters
+# xserver-backend = X backend to use (mir)
+# xserver-command = X server command to run (can also contain arguments e.g. X -special-option)
+# xmir-command = Xmir server command to run (can also contain arguments e.g. Xmir -special-option)
+# xserver-config = Config file to pass to X server
+# xserver-layout = Layout to pass to X server
+# xserver-allow-tcp = True if TCP/IP connections are allowed to this X server
+# xserver-share = True if the X server is shared for both greeter and session
+# xserver-hostname = Hostname of X server (only for type=xremote)
+# xserver-display-number = Display number of X server (only for type=xremote)
+# xdmcp-manager = XDMCP manager to connect to (implies xserver-allow-tcp=true)
+# xdmcp-port = XDMCP UDP/IP port to communicate on
+# xdmcp-key = Authentication key to use for XDM-AUTHENTICATION-1 (stored in keys.conf)
+# unity-compositor-command = Unity compositor command to run (can also contain arguments e.g. unity-system-compositor -special-option)
+# unity-compositor-timeout = Number of seconds to wait for compositor to start
+# greeter-session = Session to load for greeter
+# greeter-hide-users = True to hide the user list
+# greeter-allow-guest = True if the greeter should show a guest login option
+# greeter-show-manual-login = True if the greeter should offer a manual login option
+# greeter-show-remote-login = True if the greeter should offer a remote login option
+# user-session = Session to load for users
+# allow-user-switching = True if allowed to switch users
+# allow-guest = True if guest login is allowed
+# guest-session = Session to load for guests (overrides user-session)
+# session-wrapper = Wrapper script to run session with
+# greeter-wrapper = Wrapper script to run greeter with
+# guest-wrapper = Wrapper script to run guest sessions with
+# display-setup-script = Script to run when starting a greeter session (runs as root)
+# display-stopped-script = Script to run after stopping the display server (runs as root)
+# greeter-setup-script = Script to run when starting a greeter (runs as root)
+# session-setup-script = Script to run when starting a user session (runs as root)
+# session-cleanup-script = Script to run when quitting a user session (runs as root)
+# autologin-guest = True to log in as guest by default
+# autologin-user = User to log in with by default (overrides autologin-guest)
+# autologin-user-timeout = Number of seconds to wait before loading default user
+# autologin-session = Session to load for automatic login (overrides user-session)
+# autologin-in-background = True if autologin session should not be immediately activated
+# exit-on-failure = True if the daemon should exit if this seat fails
+# fallback-test = Script to run to check if hardware can handle Wayland - should return 1 if so
+# fallback-session = Session to launch if fallback-test returns 0
+# fallback-greeter = Greeter session to launch if fallback-test returns 0
+#
+[Seat:*]
+#type=local
+#pam-service=lightdm
+#pam-autologin-service=lightdm-autologin
+#pam-greeter-service=lightdm-greeter
+#xserver-backend=
+#xserver-command=X
+#xmir-command=Xmir
+#xserver-config=
+#xserver-layout=
+#xserver-allow-tcp=false
+#xserver-share=true
+#xserver-hostname=
+#xserver-display-number=
+#xdmcp-manager=
+#xdmcp-port=177
+#xdmcp-key=
+#unity-compositor-command=unity-system-compositor
+#unity-compositor-timeout=60
+greeter-session=pi-greeter-labwc
+greeter-hide-users=false
+#greeter-allow-guest=true
+#greeter-show-manual-login=false
+#greeter-show-remote-login=true
+user-session=LXDE-pi-labwc
+#allow-user-switching=true
+#allow-guest=true
+#guest-session=
+#session-wrapper=lightdm-session
+#greeter-wrapper=
+#guest-wrapper=
+display-setup-script=/usr/share/dispsetup.sh
+#display-stopped-script=
+#greeter-setup-script=
+#session-setup-script=
+#session-cleanup-script=
+#autologin-guest=false
+autologin-user=pi
+#autologin-user-timeout=0
+#autologin-in-background=false
+autologin-session=LXDE-pi-labwc
+#exit-on-failure=false
+#fallback-test=
+#fallback-session=
+#fallback-greeter=
+
+#
+# XDMCP Server configuration
+#
+# enabled = True if XDMCP connections should be allowed
+# port = UDP/IP port to listen for connections on
+# listen-address = Host/address to listen for XDMCP connections (use all addresses if not present)
+# key = Authentication key to use for XDM-AUTHENTICATION-1 or blank to not use authentication (stored in keys.conf)
+# hostname = Hostname to report to XDMCP clients (defaults to system hostname if unset)
+#
+# The authentication key is a 56 bit DES key specified in hex as 0xnnnnnnnnnnnnnn.  Alternatively
+# it can be a word and the first 7 characters are used as the key.
+#
+[XDMCPServer]
+#enabled=false
+#port=177
+#listen-address=
+#key=
+#hostname=
+
+#
+# VNC Server configuration
+#
+# enabled = True if VNC connections should be allowed
+# command = Command to run Xvnc server with
+# port = TCP/IP port to listen for connections on
+# listen-address = Host/address to listen for VNC connections (use all addresses if not present)
+# width = Width of display to use
+# height = Height of display to use
+# depth = Color depth of display to use
+#
+[VNCServer]
+#enabled=false
+#command=Xvnc
+#port=5900
+#listen-address=
+#width=1024
+#height=768
+#depth=8

--- a/software/distro/setup/planktoscope-app-env/wizards/remove.sh
+++ b/software/distro/setup/planktoscope-app-env/wizards/remove.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eux
+
+# Disable the first-boot graphical wizard
+if ! sudo -E apt-get purge -y -o Dpkg::Progress-Fancy=0 piwiz;
+  echo "piwiz is already not installed, so no need to remove it!"
+fi

--- a/software/distro/setup/planktoscope-app-env/wizards/remove.sh
+++ b/software/distro/setup/planktoscope-app-env/wizards/remove.sh
@@ -6,4 +6,4 @@
 # else
 #   sudo -E apt-get autoremove -y -o Dpkg::Progress-Fancy=0
 # fi
-rm -f /etc/xdg/autostart/piwiz.desktop
+sudo rm -f /etc/xdg/autostart/piwiz.desktop

--- a/software/distro/setup/planktoscope-app-env/wizards/remove.sh
+++ b/software/distro/setup/planktoscope-app-env/wizards/remove.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -eux
 
 # Disable the first-boot graphical wizard
-if ! sudo -E apt-get purge -y -o Dpkg::Progress-Fancy=0 piwiz; then
-  echo "piwiz is already not installed, so no need to remove it!"
-else
-  sudo -E apt-get autoremove -y -o Dpkg::Progress-Fancy=0
-fi
+# if ! sudo -E apt-get purge -y -o Dpkg::Progress-Fancy=0 piwiz; then
+#   echo "piwiz is already not installed, so no need to remove it!"
+# else
+#   sudo -E apt-get autoremove -y -o Dpkg::Progress-Fancy=0
+# fi
+rm -f /etc/xdg/autostart/piwiz.desktop

--- a/software/distro/setup/planktoscope-app-env/wizards/remove.sh
+++ b/software/distro/setup/planktoscope-app-env/wizards/remove.sh
@@ -3,4 +3,6 @@
 # Disable the first-boot graphical wizard
 if ! sudo -E apt-get purge -y -o Dpkg::Progress-Fancy=0 piwiz; then
   echo "piwiz is already not installed, so no need to remove it!"
+else
+  sudo -E apt-get autoremove -y -o Dpkg::Progress-Fancy=0
 fi

--- a/software/distro/setup/planktoscope-app-env/wizards/remove.sh
+++ b/software/distro/setup/planktoscope-app-env/wizards/remove.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 
 # Disable the first-boot graphical wizard
-if ! sudo -E apt-get purge -y -o Dpkg::Progress-Fancy=0 piwiz;
+if ! sudo -E apt-get purge -y -o Dpkg::Progress-Fancy=0 piwiz; then
   echo "piwiz is already not installed, so no need to remove it!"
 fi

--- a/software/distro/setup/planktoscope-app-env/wizards/remove.sh
+++ b/software/distro/setup/planktoscope-app-env/wizards/remove.sh
@@ -1,9 +1,11 @@
 #!/bin/bash -eux
 
+# Determine the base path for copied files
+config_files_root="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
 # Disable the first-boot graphical wizard
-# if ! sudo -E apt-get purge -y -o Dpkg::Progress-Fancy=0 piwiz; then
-#   echo "piwiz is already not installed, so no need to remove it!"
-# else
-#   sudo -E apt-get autoremove -y -o Dpkg::Progress-Fancy=0
-# fi
-sudo rm -f /etc/xdg/autostart/piwiz.desktop
+if [ -f /etc/xdg/autostart/piwiz.desktop ]; then
+  sudo mv /etc/xdg/autostart/piwiz.desktop /etc/xdg/autostart/piwiz.desktop.disabled
+  file="/etc/lightdm/lightdm.conf"
+  sudo cp "$config_files_root$file" "$file"
+fi


### PR DESCRIPTION
This PR attempts to resolve an issue discussed in the [2025-02-06 software meeting](https://docs.google.com/document/d/1AN1jaIdfKChKjMnzSd3ecjRTZGOnoglBfV9LCpevMgk/edit?tab=t.0#heading=h.zhpopnx24oy0) and the [2025-02-20 software meeting](https://docs.google.com/document/d/1AN1jaIdfKChKjMnzSd3ecjRTZGOnoglBfV9LCpevMgk/edit?tab=t.0#heading=h.cqkk5ghstbcn), that the graphical desktop (i.e. "-dx") OS images display a first-boot configuration wizard which:

- allows the user to change the username away from `pi` in the first-boot setup wizard, which would break PlanktoScope programs which assume use of the `pi` user
- allows the user to change the timezone away from UTC
- allows the user to change the locale away from en-US, which breaks the `generate-machine-name` service which only works if the en-US locale is set (this bug will be fixed in a separate PR to fall back to en-US for unrecognized locales)

To work around this problem, this PR attempts to disable the graphical desktop's first-boot configuration wizard.