### PR TITLE
Add default config for PlanktoScope v3

### DIFF
--- a/software/node-red-dashboard/default-configs/v3.0.config.json
+++ b/software/node-red-dashboard/default-configs/v3.0.config.json
@@ -1,0 +1,20 @@
+{
+    "sample_project": "Project's name",
+    "sample_id": 1,
+    "sample_ship": "Vessel name",
+    "sample_operator": "Operator's name",
+    "sample_sampling_gear": "net",
+    "sample_gear_net_opening": 40,
+    "acq_id": 1,
+    "acq_instrument": "PlanktoScope v3.0",
+    "acq_celltype": 300,
+    "acq_minimum_mesh": 10,
+    "acq_maximum_mesh": 200,
+    "acq_volume": 1,
+    "object_depth_min": 1,
+    "object_depth_max": 2,
+    "process_id": 1,
+    "nb_frame": 100,
+    "sleep_before": 0.5,
+    "imaging_pump_volume": 0.01
+}


### PR DESCRIPTION
Related to

* https://github.com/PlanktoScope/device-backend/pull/76

Aside from the new acq_instrument "PlanktoScope v3.0" this is a copy paste from v2.6.config.json

Todo

* [ ] ~Replace `fairscope-latest.hardware.json` ?~ later, added to the PlanktoScope v3 checklist

@chevreuill3000 do we expect any change in here for v3 aside from the `acq_instrument` ?