### PR TITLE
backend: Use gpiozero for steppers

### DIFF
--- a/device-backend/control/planktoscopehat/shush/board.py
+++ b/device-backend/control/planktoscopehat/shush/board.py
@@ -19,20 +19,20 @@ class Board:
         # Only applies to Raspberry Pi
 
         # Define chip select pins
-        self.m0_cs = DigitalOutputDevice(s1.m0_cs)
-        self.m1_cs = DigitalOutputDevice(s1.m1_cs)
+        # self.m0_cs = DigitalOutputDevice(s1.m0_cs)
+        # self.m1_cs = DigitalOutputDevice(s1.m1_cs)
 
         # Define error and stall pins
         self.error = DigitalInputDevice(s1.error)
         self.stall = DigitalInputDevice(s1.stall)
 
         # Pull all cs pins HIGH (LOW initializes data transmission)
-        self.m0_cs.on()
-        self.m1_cs.on()
+        # self.m0_cs.on()
+        # self.m1_cs.on()
 
     def deinit_gpio_state(self):
-        self.m0_cs.close()
-        self.m1_cs.close()
+        # self.m0_cs.close()
+        # self.m1_cs.close()
         self.error.close()
         self.stall.close()
 

--- a/device-backend/control/planktoscopehat/shush/boards/pscope_hat_0_1.py
+++ b/device-backend/control/planktoscopehat/shush/boards/pscope_hat_0_1.py
@@ -3,9 +3,9 @@ __author__ = "RBazile"
 # Define SPI Chip Select pin for each motor using RPi GPIO
 # Define enable pins to enable/disable motor
 
-m0_cs = 27
+# m0_cs = 8
 m0_enable = 23
-m1_cs = 17
+# m1_cs = 7
 m1_enable = 5
 error = 16
 stall = 20

--- a/device-backend/control/planktoscopehat/shush/motor.py
+++ b/device-backend/control/planktoscopehat/shush/motor.py
@@ -10,11 +10,11 @@ class Motor(Board):
         # Setting the CS and enable pins according to the motor number called
 
         if motor == 0:
-            self.chip_select = s1.m0_cs
+            # self.chip_select = s1.m0_cs
             self.enable = DigitalOutputDevice(s1.m0_enable, active_high=False)
             self.spi = Board.spi0
         elif motor == 1:
-            self.chip_select = s1.m1_cs
+            # self.chip_select = s1.m1_cs
             self.enable = DigitalOutputDevice(s1.m1_enable, active_high=False)
             self.spi = Board.spi1
 


### PR DESCRIPTION
This completes the transition from rpi.gpio to gpiozero for the PlanktoScope hat
Remaining code related to `m0_cs` and `m1_cs` was commented out as it was unused and confusing.
This was tested on a PlanktoScope v2.6 and PlanktoScope v3.0

The relevant stepper code will eventually be extracted from ShushEngine to simplify and clarify. 

Partially fixes https://github.com/PlanktoScope/PlanktoScope/issues/323 (not fully as the adafruithat still uses rpi.gpio)