### PR TITLE
dashboard: Remove dependency on gpio

### DIFF
--- a/software/node-red-dashboard/adafruithat/flows.json
+++ b/software/node-red-dashboard/adafruithat/flows.json
@@ -3404,6 +3404,21 @@
         ]
     },
     {
+        "id": "cbb8afed.0a026",
+        "type": "rpi-gpio out",
+        "z": "bccd1f23.87219",
+        "name": "LED Output",
+        "pin": "21",
+        "set": true,
+        "level": "0",
+        "freq": "",
+        "out": "out",
+        "bcm": true,
+        "x": 550,
+        "y": 120,
+        "wires": []
+    },
+    {
         "id": "3cb96380.e575ec",
         "type": "function",
         "z": "bccd1f23.87219",
@@ -3631,6 +3646,31 @@
         ]
     },
     {
+        "id": "9a1d0e7c.2d5a1",
+        "type": "inject",
+        "z": "bccd1f23.87219",
+        "name": "Default: OFF",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "off",
+        "payloadType": "str",
+        "x": 130,
+        "y": 120,
+        "wires": [
+            [
+                "f0775525.cf806"
+            ]
+        ]
+    },
+    {
         "id": "f782a471.447748",
         "type": "inject",
         "z": "bccd1f23.87219",
@@ -3810,6 +3850,43 @@
         "wires": [
             [
                 "62030521.88317c"
+            ]
+        ]
+    },
+    {
+        "id": "f0775525.cf806",
+        "type": "ui_multistate_switch",
+        "z": "bccd1f23.87219",
+        "name": "light_control",
+        "group": "4248342d.e55fac",
+        "order": 1,
+        "width": 5,
+        "height": 1,
+        "label": "Light  ",
+        "stateField": "payload",
+        "enableField": "enable",
+        "rounded": true,
+        "useThemeColors": true,
+        "hideSelectedLabel": false,
+        "options": [
+            {
+                "label": "Off",
+                "value": "0",
+                "valueType": "num",
+                "color": "#009933"
+            },
+            {
+                "label": "On",
+                "value": "1",
+                "valueType": "num",
+                "color": "#999999"
+            }
+        ],
+        "x": 350,
+        "y": 120,
+        "wires": [
+            [
+                "cbb8afed.0a026"
             ]
         ]
     },
@@ -7053,6 +7130,64 @@
         ]
     },
     {
+        "id": "43cf8ff7.75231",
+        "type": "rpi-gpio out",
+        "z": "9daf9e2b.019fc",
+        "name": "Pump Enable",
+        "pin": "4",
+        "set": true,
+        "level": "1",
+        "freq": "",
+        "out": "out",
+        "bcm": true,
+        "x": 420,
+        "y": 80,
+        "wires": []
+    },
+    {
+        "id": "4bca8a25.15be3c",
+        "type": "rpi-gpio out",
+        "z": "9daf9e2b.019fc",
+        "name": "Focus Enable",
+        "pin": "12",
+        "set": true,
+        "level": "1",
+        "freq": "",
+        "out": "out",
+        "bcm": true,
+        "x": 420,
+        "y": 120,
+        "wires": []
+    },
+    {
+        "id": "50f9b5b.a84bccc",
+        "type": "inject",
+        "z": "9daf9e2b.019fc",
+        "name": "Default: ON",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": "0.01",
+        "topic": "",
+        "payload": "true",
+        "payloadType": "bool",
+        "x": 150,
+        "y": 100,
+        "wires": [
+            [
+                "43cf8ff7.75231",
+                "4bca8a25.15be3c",
+                "6db0fcf5.f0effc",
+                "5fc4ede4.72516c"
+            ]
+        ]
+    },
+    {
         "id": "45a7b5aa.2ed20c",
         "type": "link in",
         "z": "9daf9e2b.019fc",
@@ -7084,6 +7219,36 @@
                 "4af9112d.87767"
             ]
         ]
+    },
+    {
+        "id": "5fc4ede4.72516c",
+        "type": "rpi-gpio out",
+        "z": "9daf9e2b.019fc",
+        "name": "HAT Pump Enable",
+        "pin": "23",
+        "set": true,
+        "level": "1",
+        "freq": "",
+        "out": "out",
+        "bcm": true,
+        "x": 430,
+        "y": 40,
+        "wires": []
+    },
+    {
+        "id": "6db0fcf5.f0effc",
+        "type": "rpi-gpio out",
+        "z": "9daf9e2b.019fc",
+        "name": "HAT Focus Enable",
+        "pin": "5",
+        "set": true,
+        "level": "1",
+        "freq": "",
+        "out": "out",
+        "bcm": true,
+        "x": 430,
+        "y": 160,
+        "wires": []
     },
     {
         "id": "38c05fcb891c82bf",

--- a/software/node-red-dashboard/adafruithat/package-lock.json
+++ b/software/node-red-dashboard/adafruithat/package-lock.json
@@ -1,7 +1,7 @@
 {
     "name": "planktoscope-node-red-dashboard",
     "version": "2024.0.0",
-    "lockfileVersion": 2,
+    "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
@@ -76,20 +76,20 @@
             }
         },
         "node_modules/@flowfuse/node-red-dashboard": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/node-red-dashboard/-/node-red-dashboard-1.22.1.tgz",
-            "integrity": "sha512-3PQN93riBj/u+rcvnPVkFlAeN8PP0OaIbhKrQWd5Un3GDT1fFOR6AFV2CLTToZHqc03YatUWKZxqyh2W1UH2vg==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/node-red-dashboard/-/node-red-dashboard-1.23.0.tgz",
+            "integrity": "sha512-dSR1koaulB/1nLke7KhtJdca3o8TYSXKq35yM9Rf0ZUXm05aF4Ex2yriifsbJjMb0qlg9UkiHpSdU+flb/6cNw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "acorn": "^8.11.2",
-                "axios": "^1.7.7",
+                "acorn": "^8.14.1",
+                "axios": "^1.8.4",
                 "chartjs-adapter-luxon": "^1.3.1",
-                "core-js": "^3.32.0",
-                "d3": "^7.8.5",
+                "core-js": "^3.41.0",
+                "d3": "^7.9.0",
                 "escodegen": "^2.1.0",
                 "express": "^4.21.2",
-                "socket.io": "^4.7.1",
-                "vue": "^3.4.5"
+                "socket.io": "^4.8.1",
+                "vue": "^3.5.13"
             },
             "engines": {
                 "node": ">=14"
@@ -123,29 +123,27 @@
             "peer": true
         },
         "node_modules/@socket.io/component-emitter": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
-        },
-        "node_modules/@types/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+            "license": "MIT"
         },
         "node_modules/@types/cors": {
             "version": "2.8.17",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
             "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/node": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+            "version": "22.14.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+            "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+            "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@vue/compiler-core": {
@@ -258,6 +256,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
             "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-types": "~2.1.34",
                 "negotiator": "0.6.3"
@@ -305,6 +304,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "license": "MIT",
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
             }
@@ -333,15 +333,6 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-        "node_modules/body-parser/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/body-parser/node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -355,9 +346,10 @@
             }
         },
         "node_modules/bytes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -392,9 +384,9 @@
             }
         },
         "node_modules/chart.js": {
-            "version": "4.4.8",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
-            "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+            "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -439,6 +431,7 @@
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
             "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": ">= 1.43.0 < 2"
             },
@@ -447,20 +440,30 @@
             }
         },
         "node_modules/compression": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+            "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+            "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.5",
-                "bytes": "3.0.0",
-                "compressible": "~2.0.16",
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
                 "debug": "2.6.9",
+                "negotiator": "~0.6.4",
                 "on-headers": "~1.0.2",
-                "safe-buffer": "5.1.2",
+                "safe-buffer": "5.2.1",
                 "vary": "~1.1.2"
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/content-disposition": {
@@ -475,26 +478,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/content-disposition/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/content-type": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -505,9 +488,10 @@
             }
         },
         "node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -539,6 +523,7 @@
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
             "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "license": "MIT",
             "dependencies": {
                 "object-assign": "^4",
                 "vary": "^1"
@@ -557,9 +542,9 @@
             }
         },
         "node_modules/cronstrue": {
-            "version": "2.57.0",
-            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.57.0.tgz",
-            "integrity": "sha512-gQOfxJa1RA9uDT4hx37NshhX4dW9t9zTCtIYu15LUziH+mkpuLXYcSEyM8ZewMJ2p8UVuHGjI3n4hGpu3HtCbg==",
+            "version": "2.59.0",
+            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.59.0.tgz",
+            "integrity": "sha512-YKGmAy84hKH+hHIIER07VCAHf9u0Ldelx1uU6EBxsRPDXIA1m5fsKmJfyC3xBhw6cVC/1i83VdbL4PvepTrt8A==",
             "license": "MIT",
             "bin": {
                 "cronstrue": "bin/cli.js"
@@ -976,6 +961,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -1002,6 +988,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1010,6 +997,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
@@ -1032,22 +1020,24 @@
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
         },
         "node_modules/engine.io": {
-            "version": "6.6.2",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
-            "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+            "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+            "license": "MIT",
             "dependencies": {
-                "@types/cookie": "^0.4.1",
                 "@types/cors": "^2.8.12",
                 "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
@@ -1066,14 +1056,25 @@
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
             "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/engine.io/node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/engine.io/node_modules/debug": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -1089,7 +1090,8 @@
         "node_modules/engine.io/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/entities": {
             "version": "4.5.0",
@@ -1151,7 +1153,8 @@
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/escodegen": {
             "version": "2.1.0",
@@ -1215,6 +1218,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1264,35 +1268,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/express/node_modules/cookie": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/express/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/finalhandler": {
             "version": "1.3.1",
@@ -1360,6 +1335,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1368,6 +1344,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -1438,12 +1415,14 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "license": "ISC"
         },
         "node_modules/gridstack": {
             "version": "0.6.4",
             "resolved": "https://registry.npmjs.org/gridstack/-/gridstack-0.6.4.tgz",
             "integrity": "sha512-4ToCnneNg5Uw+ms3xHtPVvsNXdvwQhngdlyNgGkARwvooQu+gLL6xkwPqLU59TsZP/LVvofb2QhEuXyh/ocL8w==",
+            "license": "MIT",
             "dependencies": {
                 "jquery": "^1.8 || 2 || 3"
             }
@@ -1491,6 +1470,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
             "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "license": "MIT",
             "dependencies": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
@@ -1517,7 +1497,8 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
         },
         "node_modules/internmap": {
             "version": "2.0.3",
@@ -1538,14 +1519,16 @@
             }
         },
         "node_modules/jquery": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-            "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "license": "MIT"
         },
         "node_modules/jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "license": "MIT",
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -1609,6 +1592,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "license": "MIT",
             "bin": {
                 "mime": "cli.js"
             },
@@ -1620,6 +1604,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1628,6 +1613,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -1638,12 +1624,14 @@
         "node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
         },
         "node_modules/mustache": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
             "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+            "license": "MIT",
             "bin": {
                 "mustache": "bin/mustache"
             }
@@ -1670,6 +1658,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1702,41 +1691,47 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/node-red-contrib-dir2files/-/node-red-contrib-dir2files-0.3.0.tgz",
             "integrity": "sha512-1aO+tcHmPvkAMiQ2yTbxzWO4UME2dX1YGNnjZF7guIbRpVigKRk+aO/kC78irJ1hFrtpcc9I3dh920zV4Bivew==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "fs-extra": "^7.0.1",
                 "path": "^0.12.7"
             }
         },
         "node_modules/node-red-contrib-gpsd": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-gpsd/-/node-red-contrib-gpsd-1.0.7.tgz",
-            "integrity": "sha512-iQoOf+dKj2FaC7oTveNU4i24ap0iejtrlD/gpdo/iX9H95qLDvFwT2Mfbtil+UtycyCtG/2nOn+n03IJ9OtyQQ==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/node-red-contrib-gpsd/-/node-red-contrib-gpsd-1.0.8.tgz",
+            "integrity": "sha512-KLZ2/bVqyt1LD3TbfyjCzN3piR0KGVLt3RlB9vIygyc2ML1J/AyvqYrGS3fWaWtIVK0k+f+NkK6BV/DXO2q/2Q==",
+            "license": "GPL-3.0+",
             "dependencies": {
-                "node-gpsd": "^0.3.0"
+                "node-gpsd": "^0.3.4"
             }
         },
         "node_modules/node-red-contrib-python3-function": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/node-red-contrib-python3-function/-/node-red-contrib-python3-function-0.0.4.tgz",
-            "integrity": "sha512-m7JOWdUQCrX2g7IoCPUlyu1jQt31egYCbGbFenw+nB/28VMtjs9tTYrPxpraPfxU89oQ7XeiiQzq4DWKD3MAKw=="
+            "integrity": "sha512-m7JOWdUQCrX2g7IoCPUlyu1jQt31egYCbGbFenw+nB/28VMtjs9tTYrPxpraPfxU89oQ7XeiiQzq4DWKD3MAKw==",
+            "license": "MIT"
         },
         "node_modules/node-red-contrib-ui-multistate-switch": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/node-red-contrib-ui-multistate-switch/-/node-red-contrib-ui-multistate-switch-1.2.3.tgz",
             "integrity": "sha512-Bh4FiSllZSiVIWv8praWrkIM98noX47oUFQ7jVsFM9VIWA33Rda6QMh+HslT8dpjniSBrVWXBDWkrIVDwWQW8Q==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "mustache": "^4.2.0"
             }
         },
         "node_modules/node-red-dashboard": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/node-red-dashboard/-/node-red-dashboard-3.5.0.tgz",
-            "integrity": "sha512-pTGz/v7MHEUVMXokqV5wrixTyW1SGI5v5ALJkA+p7vTBh4Ho1zjAb7uc63iJkgrSHRuu0S+E1oSb9SbqKeVTCA==",
+            "version": "3.6.5",
+            "resolved": "https://registry.npmjs.org/node-red-dashboard/-/node-red-dashboard-3.6.5.tgz",
+            "integrity": "sha512-zoTVq13lh3OXzxBdFJByxaiijHLOCdkVfR5eCKXNm0RNFfGFyaqPQ06OoeLPXTmhU6KU/VDINxCKJUtdChg9Iw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "compression": "^1.7.4",
                 "gridstack": "^0.6.4",
                 "serve-static": "^1.15.0",
-                "socket.io": "^4.5.4"
+                "socket.io": "^4.7.4"
             },
             "engines": {
                 "node": ">=12"
@@ -1745,12 +1740,14 @@
         "node_modules/node-red-node-pi-gpio": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/node-red-node-pi-gpio/-/node-red-node-pi-gpio-2.0.6.tgz",
-            "integrity": "sha512-HffD0XcGARXZuPnnPvGm9oEdWD8lNzYYjQYxjtLbVbZjiC9beU0QaqD0Os7zsXtIXbUsHxXG2YXdGJpvEtqJyg=="
+            "integrity": "sha512-HffD0XcGARXZuPnnPvGm9oEdWD8lNzYYjQYxjtLbVbZjiC9beU0QaqD0Os7zsXtIXbUsHxXG2YXdGJpvEtqJyg==",
+            "license": "Apache-2.0"
         },
         "node_modules/node-red-node-ui-list": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/node-red-node-ui-list/-/node-red-node-ui-list-0.3.6.tgz",
             "integrity": "sha512-JoCJEFmLLuRRBeCP0PsqNL8YNNGYFoINnXG/ZzGLe0rovXpEshxLekpy1qR7aJQE5hRa+4KAzGBfoBQQRerUAw==",
+            "license": "Apache-2.0",
             "peerDependencies": {
                 "node-red-dashboard": ">2.15.0"
             }
@@ -1759,6 +1756,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1779,6 +1777,7 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -1790,6 +1789,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
             "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1807,6 +1807,7 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1815,6 +1816,7 @@
             "version": "0.12.7",
             "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
             "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+            "license": "MIT",
             "dependencies": {
                 "process": "^0.11.1",
                 "util": "^0.10.3"
@@ -1879,6 +1881,7 @@
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -1921,6 +1924,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1936,15 +1940,6 @@
                 "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/raw-body/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1974,9 +1969,24 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -1988,6 +1998,7 @@
             "version": "0.19.0",
             "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
             "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -2011,6 +2022,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2018,12 +2030,14 @@
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/serve-static": {
             "version": "1.16.2",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
             "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "license": "MIT",
             "dependencies": {
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
@@ -2037,7 +2051,8 @@
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
@@ -2112,9 +2127,10 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.0.tgz",
-            "integrity": "sha512-8U6BEgGjQOfGz3HHTYaC/L1GaxDCJ/KM0XTkJly0EhZ5U/du9uNEZy4ZgYzEzIqlx2CMm25CrCqr1ck899eLNA==",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+            "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
@@ -2132,17 +2148,19 @@
             "version": "2.5.5",
             "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
             "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "~4.3.4",
                 "ws": "~8.17.1"
             }
         },
         "node_modules/socket.io-adapter/node_modules/debug": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2154,14 +2172,16 @@
             }
         },
         "node_modules/socket.io-adapter/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/socket.io-parser": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
             "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+            "license": "MIT",
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1"
@@ -2171,11 +2191,12 @@
             }
         },
         "node_modules/socket.io-parser/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2187,16 +2208,18 @@
             }
         },
         "node_modules/socket.io-parser/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/socket.io/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2208,9 +2231,10 @@
             }
         },
         "node_modules/socket.io/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -2235,6 +2259,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2248,6 +2273,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.6"
             }
@@ -2266,14 +2292,16 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "license": "MIT"
         },
         "node_modules/universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -2291,6 +2319,7 @@
             "version": "0.10.4",
             "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
             "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+            "license": "MIT",
             "dependencies": {
                 "inherits": "2.0.3"
             }
@@ -2298,7 +2327,8 @@
         "node_modules/util/node_modules/inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+            "license": "ISC"
         },
         "node_modules/utils-merge": {
             "version": "1.0.1",
@@ -2313,6 +2343,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2354,6 +2385,7 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
             "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -2369,1609 +2401,6 @@
                     "optional": true
                 }
             }
-        }
-    },
-    "dependencies": {
-        "@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="
-        },
-        "@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="
-        },
-        "@babel/parser": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-            "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
-            "requires": {
-                "@babel/types": "^7.27.0"
-            }
-        },
-        "@babel/types": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-            "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
-            "requires": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
-            }
-        },
-        "@flowfuse/flow-renderer": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/flow-renderer/-/flow-renderer-0.4.1.tgz",
-            "integrity": "sha512-HQfBUd6bw0extbEgnUv4xjmPF6t+ViIcQAUqxQ7ynnzhJlfuKNnGPmezcGU8rIdKN6zHK/38bbrQIyRCVmI7uw=="
-        },
-        "@flowfuse/node-red-dashboard": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/node-red-dashboard/-/node-red-dashboard-1.22.1.tgz",
-            "integrity": "sha512-3PQN93riBj/u+rcvnPVkFlAeN8PP0OaIbhKrQWd5Un3GDT1fFOR6AFV2CLTToZHqc03YatUWKZxqyh2W1UH2vg==",
-            "requires": {
-                "acorn": "^8.11.2",
-                "axios": "^1.7.7",
-                "chartjs-adapter-luxon": "^1.3.1",
-                "core-js": "^3.32.0",
-                "d3": "^7.8.5",
-                "escodegen": "^2.1.0",
-                "express": "^4.21.2",
-                "socket.io": "^4.7.1",
-                "vue": "^3.4.5"
-            }
-        },
-        "@flowfuse/node-red-dashboard-2-ui-flowviewer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/node-red-dashboard-2-ui-flowviewer/-/node-red-dashboard-2-ui-flowviewer-1.0.1.tgz",
-            "integrity": "sha512-vifliYm0HmmJpnmoV9rX7EbK78YENpQf7xu1MH1AkZCzAalg33i7ojKnWhgvXbpshoU06kC8WR0N6kn5zG7HTw==",
-            "requires": {
-                "@flowfuse/flow-renderer": "^0.4.1",
-                "vue": "^3.3.8",
-                "vuex": "^4.1.0"
-            }
-        },
-        "@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
-        },
-        "@kurkle/color": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-            "peer": true
-        },
-        "@socket.io/component-emitter": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
-        },
-        "@types/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
-        },
-        "@types/cors": {
-            "version": "2.8.17",
-            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
-            "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/node": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-            "requires": {
-                "undici-types": "~6.19.2"
-            }
-        },
-        "@vue/compiler-core": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-            "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-            "requires": {
-                "@babel/parser": "^7.25.3",
-                "@vue/shared": "3.5.13",
-                "entities": "^4.5.0",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.0"
-            }
-        },
-        "@vue/compiler-dom": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
-            "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-            "requires": {
-                "@vue/compiler-core": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/compiler-sfc": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
-            "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
-            "requires": {
-                "@babel/parser": "^7.25.3",
-                "@vue/compiler-core": "3.5.13",
-                "@vue/compiler-dom": "3.5.13",
-                "@vue/compiler-ssr": "3.5.13",
-                "@vue/shared": "3.5.13",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.11",
-                "postcss": "^8.4.48",
-                "source-map-js": "^1.2.0"
-            }
-        },
-        "@vue/compiler-ssr": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
-            "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
-            "requires": {
-                "@vue/compiler-dom": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/devtools-api": {
-            "version": "6.6.4",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-            "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
-        },
-        "@vue/reactivity": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
-            "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
-            "requires": {
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/runtime-core": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
-            "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
-            "requires": {
-                "@vue/reactivity": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/runtime-dom": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
-            "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
-            "requires": {
-                "@vue/reactivity": "3.5.13",
-                "@vue/runtime-core": "3.5.13",
-                "@vue/shared": "3.5.13",
-                "csstype": "^3.1.3"
-            }
-        },
-        "@vue/server-renderer": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
-            "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
-            "requires": {
-                "@vue/compiler-ssr": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/shared": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="
-        },
-        "accepts": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-            "requires": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
-            }
-        },
-        "acorn": {
-            "version": "8.14.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="
-        },
-        "array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
-        "axios": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-            "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-            "requires": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
-        "base64id": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
-        },
-        "body-parser": {
-            "version": "1.20.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-            "requires": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.13.0",
-                "raw-body": "2.5.2",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "bytes": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                }
-            }
-        },
-        "bytes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
-        },
-        "call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            }
-        },
-        "call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "requires": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            }
-        },
-        "chart.js": {
-            "version": "4.4.8",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
-            "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
-            "peer": true,
-            "requires": {
-                "@kurkle/color": "^0.3.0"
-            }
-        },
-        "chartjs-adapter-luxon": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/chartjs-adapter-luxon/-/chartjs-adapter-luxon-1.3.1.tgz",
-            "integrity": "sha512-yxHov3X8y+reIibl1o+j18xzrcdddCLqsXhriV2+aQ4hCR66IYFchlRXUvrJVoxglJ380pgytU7YWtoqdIgqhg==",
-            "requires": {}
-        },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
-        "commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        },
-        "compressible": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-            "requires": {
-                "mime-db": ">= 1.43.0 < 2"
-            }
-        },
-        "compression": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
-            "requires": {
-                "accepts": "~1.3.5",
-                "bytes": "3.0.0",
-                "compressible": "~2.0.16",
-                "debug": "2.6.9",
-                "on-headers": "~1.0.2",
-                "safe-buffer": "5.1.2",
-                "vary": "~1.1.2"
-            }
-        },
-        "content-disposition": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-            "requires": {
-                "safe-buffer": "5.2.1"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                }
-            }
-        },
-        "content-type": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
-        },
-        "cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-        },
-        "cookie-signature": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-        },
-        "coord-parser": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/coord-parser/-/coord-parser-1.0.0.tgz",
-            "integrity": "sha512-rketzalr6NS1IE8QjVf90djYvfxQ97aL3onUj8VlJsGsEBbsKf6SoKK3awYTrqynLr9VEBbCkHrwayGU4XjU2Q=="
-        },
-        "core-js": {
-            "version": "3.41.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
-            "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA=="
-        },
-        "cors": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-            "requires": {
-                "object-assign": "^4",
-                "vary": "^1"
-            }
-        },
-        "cronosjs": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/cronosjs/-/cronosjs-1.7.1.tgz",
-            "integrity": "sha512-d6S6+ep7dJxsAG8OQQCdKuByI/S/AV64d9OF5mtmcykOyPu92cAkAnF3Tbc9s5oOaLQBYYQmTNvjqYRkPJ/u5Q=="
-        },
-        "cronstrue": {
-            "version": "2.57.0",
-            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.57.0.tgz",
-            "integrity": "sha512-gQOfxJa1RA9uDT4hx37NshhX4dW9t9zTCtIYu15LUziH+mkpuLXYcSEyM8ZewMJ2p8UVuHGjI3n4hGpu3HtCbg=="
-        },
-        "csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "d3": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-            "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-            "requires": {
-                "d3-array": "3",
-                "d3-axis": "3",
-                "d3-brush": "3",
-                "d3-chord": "3",
-                "d3-color": "3",
-                "d3-contour": "4",
-                "d3-delaunay": "6",
-                "d3-dispatch": "3",
-                "d3-drag": "3",
-                "d3-dsv": "3",
-                "d3-ease": "3",
-                "d3-fetch": "3",
-                "d3-force": "3",
-                "d3-format": "3",
-                "d3-geo": "3",
-                "d3-hierarchy": "3",
-                "d3-interpolate": "3",
-                "d3-path": "3",
-                "d3-polygon": "3",
-                "d3-quadtree": "3",
-                "d3-random": "3",
-                "d3-scale": "4",
-                "d3-scale-chromatic": "3",
-                "d3-selection": "3",
-                "d3-shape": "3",
-                "d3-time": "3",
-                "d3-time-format": "4",
-                "d3-timer": "3",
-                "d3-transition": "3",
-                "d3-zoom": "3"
-            }
-        },
-        "d3-array": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-            "requires": {
-                "internmap": "1 - 2"
-            }
-        },
-        "d3-axis": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
-        },
-        "d3-brush": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-            "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "3",
-                "d3-transition": "3"
-            }
-        },
-        "d3-chord": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-            "requires": {
-                "d3-path": "1 - 3"
-            }
-        },
-        "d3-color": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
-        },
-        "d3-contour": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-            "requires": {
-                "d3-array": "^3.2.0"
-            }
-        },
-        "d3-delaunay": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-            "requires": {
-                "delaunator": "5"
-            }
-        },
-        "d3-dispatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
-        },
-        "d3-drag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-            "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-selection": "3"
-            }
-        },
-        "d3-dsv": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-            "requires": {
-                "commander": "7",
-                "iconv-lite": "0.6",
-                "rw": "1"
-            }
-        },
-        "d3-ease": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
-        },
-        "d3-fetch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-            "requires": {
-                "d3-dsv": "1 - 3"
-            }
-        },
-        "d3-force": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-            "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-quadtree": "1 - 3",
-                "d3-timer": "1 - 3"
-            }
-        },
-        "d3-format": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
-        },
-        "d3-geo": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-            "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-            "requires": {
-                "d3-array": "2.5.0 - 3"
-            }
-        },
-        "d3-hierarchy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
-        },
-        "d3-interpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-            "requires": {
-                "d3-color": "1 - 3"
-            }
-        },
-        "d3-path": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
-        },
-        "d3-polygon": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
-        },
-        "d3-quadtree": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
-        },
-        "d3-random": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
-        },
-        "d3-scale": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-            "requires": {
-                "d3-array": "2.10.0 - 3",
-                "d3-format": "1 - 3",
-                "d3-interpolate": "1.2.0 - 3",
-                "d3-time": "2.1.1 - 3",
-                "d3-time-format": "2 - 4"
-            }
-        },
-        "d3-scale-chromatic": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-            "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-            "requires": {
-                "d3-color": "1 - 3",
-                "d3-interpolate": "1 - 3"
-            }
-        },
-        "d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
-        },
-        "d3-shape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-            "requires": {
-                "d3-path": "^3.1.0"
-            }
-        },
-        "d3-time": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-            "requires": {
-                "d3-array": "2 - 3"
-            }
-        },
-        "d3-time-format": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-            "requires": {
-                "d3-time": "1 - 3"
-            }
-        },
-        "d3-timer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
-        },
-        "d3-transition": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-            "requires": {
-                "d3-color": "1 - 3",
-                "d3-dispatch": "1 - 3",
-                "d3-ease": "1 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-timer": "1 - 3"
-            }
-        },
-        "d3-zoom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-            "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "2 - 3",
-                "d3-transition": "2 - 3"
-            }
-        },
-        "debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "requires": {
-                "ms": "2.0.0"
-            }
-        },
-        "delaunator": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-            "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-            "requires": {
-                "robust-predicates": "^3.0.2"
-            }
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-        },
-        "depd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        },
-        "destroy": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
-        },
-        "dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "requires": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            }
-        },
-        "ee-first": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-        },
-        "encodeurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
-        },
-        "engine.io": {
-            "version": "6.6.2",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
-            "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
-            "requires": {
-                "@types/cookie": "^0.4.1",
-                "@types/cors": "^2.8.12",
-                "@types/node": ">=10.0.0",
-                "accepts": "~1.3.4",
-                "base64id": "2.0.0",
-                "cookie": "~0.7.2",
-                "cors": "~2.8.5",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.17.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-                    "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-                    "requires": {
-                        "ms": "^2.1.3"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-                }
-            }
-        },
-        "engine.io-parser": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
-        },
-        "entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
-        },
-        "es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-        },
-        "es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-        },
-        "es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "requires": {
-                "es-errors": "^1.3.0"
-            }
-        },
-        "es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            }
-        },
-        "escape-html": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-        },
-        "escodegen": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "requires": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2",
-                "source-map": "~0.6.1"
-            }
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
-        "estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        },
-        "estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-        },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-        },
-        "etag": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-        },
-        "express": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-            "requires": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.3",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.7.1",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.3.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.13.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.19.0",
-                "serve-static": "1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "dependencies": {
-                "cookie": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-                    "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                }
-            }
-        },
-        "finalhandler": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-            "requires": {
-                "debug": "2.6.9",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "2.0.1",
-                "unpipe": "~1.0.0"
-            }
-        },
-        "follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
-        },
-        "form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "mime-types": "^2.1.12"
-            }
-        },
-        "forwarded": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
-        },
-        "fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
-        },
-        "fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            }
-        },
-        "function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-        },
-        "get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "requires": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            }
-        },
-        "get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "requires": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            }
-        },
-        "gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-        },
-        "graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-        },
-        "gridstack": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/gridstack/-/gridstack-0.6.4.tgz",
-            "integrity": "sha512-4ToCnneNg5Uw+ms3xHtPVvsNXdvwQhngdlyNgGkARwvooQu+gLL6xkwPqLU59TsZP/LVvofb2QhEuXyh/ocL8w==",
-            "requires": {
-                "jquery": "^1.8 || 2 || 3"
-            }
-        },
-        "has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-        },
-        "has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "requires": {
-                "has-symbols": "^1.0.3"
-            }
-        },
-        "hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "requires": {
-                "function-bind": "^1.1.2"
-            }
-        },
-        "http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-            "requires": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            }
-        },
-        "iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "internmap": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
-        },
-        "ipaddr.js": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-        },
-        "jquery": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-            "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
-        },
-        "jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "requires": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "luxon": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
-            "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
-            "peer": true
-        },
-        "magic-string": {
-            "version": "0.30.17",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-            "requires": {
-                "@jridgewell/sourcemap-codec": "^1.5.0"
-            }
-        },
-        "math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-        },
-        "media-typer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
-        },
-        "merge-descriptors": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
-        },
-        "methods": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
-        },
-        "mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-        },
-        "mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "requires": {
-                "mime-db": "1.52.0"
-            }
-        },
-        "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        },
-        "mustache": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-            "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
-        },
-        "nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
-        },
-        "negotiator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-        },
-        "node-gpsd": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/node-gpsd/-/node-gpsd-0.3.4.tgz",
-            "integrity": "sha512-sI9hPfHiaWDmhjE1oJZnhMo7UF2vQVGl3qk0K4HbN1L8BkS0I+rd6V687eHOj/6ervXiHrhwXzYYsWdXxGy0Qg=="
-        },
-        "node-red-contrib-cron-plus": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-cron-plus/-/node-red-contrib-cron-plus-2.1.0.tgz",
-            "integrity": "sha512-qiEvEpnQgFdjEX5PBv8CXt/kJEIbuf0D0rhxr3S0pcup6Jb1r4GhGsBHvkdzxheLOIDnzS1GlGBYYUGgU+5smQ==",
-            "requires": {
-                "coord-parser": "^1.0.0",
-                "cronosjs": "^1.7.1",
-                "cronstrue": "^2.28.0",
-                "pretty-ms": "7.0.1",
-                "suncalc2": "^1.8.1"
-            }
-        },
-        "node-red-contrib-dir2files": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-dir2files/-/node-red-contrib-dir2files-0.3.0.tgz",
-            "integrity": "sha512-1aO+tcHmPvkAMiQ2yTbxzWO4UME2dX1YGNnjZF7guIbRpVigKRk+aO/kC78irJ1hFrtpcc9I3dh920zV4Bivew==",
-            "requires": {
-                "fs-extra": "^7.0.1",
-                "path": "^0.12.7"
-            }
-        },
-        "node-red-contrib-gpsd": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-gpsd/-/node-red-contrib-gpsd-1.0.7.tgz",
-            "integrity": "sha512-iQoOf+dKj2FaC7oTveNU4i24ap0iejtrlD/gpdo/iX9H95qLDvFwT2Mfbtil+UtycyCtG/2nOn+n03IJ9OtyQQ==",
-            "requires": {
-                "node-gpsd": "^0.3.0"
-            }
-        },
-        "node-red-contrib-python3-function": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-python3-function/-/node-red-contrib-python3-function-0.0.4.tgz",
-            "integrity": "sha512-m7JOWdUQCrX2g7IoCPUlyu1jQt31egYCbGbFenw+nB/28VMtjs9tTYrPxpraPfxU89oQ7XeiiQzq4DWKD3MAKw=="
-        },
-        "node-red-contrib-ui-multistate-switch": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-ui-multistate-switch/-/node-red-contrib-ui-multistate-switch-1.2.3.tgz",
-            "integrity": "sha512-Bh4FiSllZSiVIWv8praWrkIM98noX47oUFQ7jVsFM9VIWA33Rda6QMh+HslT8dpjniSBrVWXBDWkrIVDwWQW8Q==",
-            "requires": {
-                "mustache": "^4.2.0"
-            }
-        },
-        "node-red-dashboard": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/node-red-dashboard/-/node-red-dashboard-3.5.0.tgz",
-            "integrity": "sha512-pTGz/v7MHEUVMXokqV5wrixTyW1SGI5v5ALJkA+p7vTBh4Ho1zjAb7uc63iJkgrSHRuu0S+E1oSb9SbqKeVTCA==",
-            "requires": {
-                "compression": "^1.7.4",
-                "gridstack": "^0.6.4",
-                "serve-static": "^1.15.0",
-                "socket.io": "^4.5.4"
-            }
-        },
-        "node-red-node-pi-gpio": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/node-red-node-pi-gpio/-/node-red-node-pi-gpio-2.0.6.tgz",
-            "integrity": "sha512-HffD0XcGARXZuPnnPvGm9oEdWD8lNzYYjQYxjtLbVbZjiC9beU0QaqD0Os7zsXtIXbUsHxXG2YXdGJpvEtqJyg=="
-        },
-        "node-red-node-ui-list": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/node-red-node-ui-list/-/node-red-node-ui-list-0.3.6.tgz",
-            "integrity": "sha512-JoCJEFmLLuRRBeCP0PsqNL8YNNGYFoINnXG/ZzGLe0rovXpEshxLekpy1qR7aJQE5hRa+4KAzGBfoBQQRerUAw==",
-            "requires": {}
-        },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-        },
-        "object-inspect": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
-        },
-        "on-finished": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-            "requires": {
-                "ee-first": "1.1.1"
-            }
-        },
-        "on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
-        },
-        "parse-ms": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-            "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
-        },
-        "parseurl": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-        },
-        "path": {
-            "version": "0.12.7",
-            "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-            "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-            "requires": {
-                "process": "^0.11.1",
-                "util": "^0.10.3"
-            }
-        },
-        "path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
-        },
-        "picocolors": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
-        },
-        "postcss": {
-            "version": "8.5.3",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
-            "requires": {
-                "nanoid": "^3.3.8",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "pretty-ms": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-            "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
-            "requires": {
-                "parse-ms": "^2.1.0"
-            }
-        },
-        "process": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
-        },
-        "proxy-addr": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-            "requires": {
-                "forwarded": "0.2.0",
-                "ipaddr.js": "1.9.1"
-            }
-        },
-        "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
-        "qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-            "requires": {
-                "side-channel": "^1.0.6"
-            }
-        },
-        "range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-        },
-        "raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-            "requires": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "bytes": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                }
-            }
-        },
-        "robust-predicates": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
-        },
-        "rw": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-            "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
-        },
-        "safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "send": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-            "requires": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
-            },
-            "dependencies": {
-                "encodeurl": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-                    "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-                }
-            }
-        },
-        "serve-static": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-            "requires": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.19.0"
-            }
-        },
-        "setprototypeof": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-        },
-        "side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
-                "side-channel-map": "^1.0.1",
-                "side-channel-weakmap": "^1.0.2"
-            }
-        },
-        "side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
-            }
-        },
-        "side-channel-map": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3"
-            }
-        },
-        "side-channel-weakmap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3",
-                "side-channel-map": "^1.0.1"
-            }
-        },
-        "socket.io": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.0.tgz",
-            "integrity": "sha512-8U6BEgGjQOfGz3HHTYaC/L1GaxDCJ/KM0XTkJly0EhZ5U/du9uNEZy4ZgYzEzIqlx2CMm25CrCqr1ck899eLNA==",
-            "requires": {
-                "accepts": "~1.3.4",
-                "base64id": "~2.0.0",
-                "cors": "~2.8.5",
-                "debug": "~4.3.2",
-                "engine.io": "~6.6.0",
-                "socket.io-adapter": "~2.5.2",
-                "socket.io-parser": "~4.2.4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
-            }
-        },
-        "socket.io-adapter": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-            "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-            "requires": {
-                "debug": "~4.3.4",
-                "ws": "~8.17.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.5",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-                    "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
-            }
-        },
-        "socket.io-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-            "requires": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
-            }
-        },
-        "source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "optional": true
-        },
-        "source-map-js": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
-        },
-        "statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-        },
-        "suncalc2": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/suncalc2/-/suncalc2-1.8.1.tgz",
-            "integrity": "sha512-tNoAni1LqWzBzJRX3NRCsD50gVsuejH1jd9Y+XyKO3WkpPIU+QNyWF4Zf2JnUQKW2LKLWIBgVDQCrgsQwqs0tA=="
-        },
-        "toidentifier": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-        },
-        "type-is": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-            "requires": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
-            }
-        },
-        "undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-        },
-        "universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-        },
-        "unpipe": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
-        },
-        "util": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-            "requires": {
-                "inherits": "2.0.3"
-            },
-            "dependencies": {
-                "inherits": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
-                }
-            }
-        },
-        "utils-merge": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
-        },
-        "vary": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-        },
-        "vue": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
-            "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
-            "requires": {
-                "@vue/compiler-dom": "3.5.13",
-                "@vue/compiler-sfc": "3.5.13",
-                "@vue/runtime-dom": "3.5.13",
-                "@vue/server-renderer": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "vuex": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
-            "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
-            "requires": {
-                "@vue/devtools-api": "^6.0.0-beta.11"
-            }
-        },
-        "ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-            "requires": {}
         }
     }
 }

--- a/software/node-red-dashboard/planktoscopehat/package-lock.json
+++ b/software/node-red-dashboard/planktoscopehat/package-lock.json
@@ -1,7 +1,7 @@
 {
     "name": "planktoscope-node-red-dashboard",
     "version": "2024.0.0",
-    "lockfileVersion": 2,
+    "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
@@ -16,7 +16,6 @@
                 "node-red-contrib-python3-function": "^0.0.4",
                 "node-red-contrib-ui-multistate-switch": "^1.2.2",
                 "node-red-dashboard": "^3.1.2",
-                "node-red-node-pi-gpio": "^2.0.1",
                 "node-red-node-ui-list": "^0.3.6"
             }
         },
@@ -76,20 +75,20 @@
             }
         },
         "node_modules/@flowfuse/node-red-dashboard": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/node-red-dashboard/-/node-red-dashboard-1.22.1.tgz",
-            "integrity": "sha512-3PQN93riBj/u+rcvnPVkFlAeN8PP0OaIbhKrQWd5Un3GDT1fFOR6AFV2CLTToZHqc03YatUWKZxqyh2W1UH2vg==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/node-red-dashboard/-/node-red-dashboard-1.23.0.tgz",
+            "integrity": "sha512-dSR1koaulB/1nLke7KhtJdca3o8TYSXKq35yM9Rf0ZUXm05aF4Ex2yriifsbJjMb0qlg9UkiHpSdU+flb/6cNw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "acorn": "^8.11.2",
-                "axios": "^1.7.7",
+                "acorn": "^8.14.1",
+                "axios": "^1.8.4",
                 "chartjs-adapter-luxon": "^1.3.1",
-                "core-js": "^3.32.0",
-                "d3": "^7.8.5",
+                "core-js": "^3.41.0",
+                "d3": "^7.9.0",
                 "escodegen": "^2.1.0",
                 "express": "^4.21.2",
-                "socket.io": "^4.7.1",
-                "vue": "^3.4.5"
+                "socket.io": "^4.8.1",
+                "vue": "^3.5.13"
             },
             "engines": {
                 "node": ">=14"
@@ -123,29 +122,27 @@
             "peer": true
         },
         "node_modules/@socket.io/component-emitter": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
-        },
-        "node_modules/@types/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+            "license": "MIT"
         },
         "node_modules/@types/cors": {
             "version": "2.8.17",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
             "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/node": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+            "version": "22.14.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+            "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+            "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@vue/compiler-core": {
@@ -258,6 +255,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
             "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-types": "~2.1.34",
                 "negotiator": "0.6.3"
@@ -305,6 +303,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "license": "MIT",
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
             }
@@ -333,15 +332,6 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-        "node_modules/body-parser/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/body-parser/node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -355,9 +345,10 @@
             }
         },
         "node_modules/bytes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -392,9 +383,9 @@
             }
         },
         "node_modules/chart.js": {
-            "version": "4.4.8",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
-            "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+            "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -439,6 +430,7 @@
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
             "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": ">= 1.43.0 < 2"
             },
@@ -447,20 +439,30 @@
             }
         },
         "node_modules/compression": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+            "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+            "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.5",
-                "bytes": "3.0.0",
-                "compressible": "~2.0.16",
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
                 "debug": "2.6.9",
+                "negotiator": "~0.6.4",
                 "on-headers": "~1.0.2",
-                "safe-buffer": "5.1.2",
+                "safe-buffer": "5.2.1",
                 "vary": "~1.1.2"
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/content-disposition": {
@@ -475,26 +477,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/content-disposition/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/content-type": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -505,9 +487,10 @@
             }
         },
         "node_modules/cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -539,6 +522,7 @@
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
             "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "license": "MIT",
             "dependencies": {
                 "object-assign": "^4",
                 "vary": "^1"
@@ -557,9 +541,9 @@
             }
         },
         "node_modules/cronstrue": {
-            "version": "2.57.0",
-            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.57.0.tgz",
-            "integrity": "sha512-gQOfxJa1RA9uDT4hx37NshhX4dW9t9zTCtIYu15LUziH+mkpuLXYcSEyM8ZewMJ2p8UVuHGjI3n4hGpu3HtCbg==",
+            "version": "2.59.0",
+            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.59.0.tgz",
+            "integrity": "sha512-YKGmAy84hKH+hHIIER07VCAHf9u0Ldelx1uU6EBxsRPDXIA1m5fsKmJfyC3xBhw6cVC/1i83VdbL4PvepTrt8A==",
             "license": "MIT",
             "bin": {
                 "cronstrue": "bin/cli.js"
@@ -976,6 +960,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -1002,6 +987,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1010,6 +996,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
@@ -1032,22 +1019,24 @@
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
         },
         "node_modules/engine.io": {
-            "version": "6.6.2",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
-            "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+            "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+            "license": "MIT",
             "dependencies": {
-                "@types/cookie": "^0.4.1",
                 "@types/cors": "^2.8.12",
                 "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
@@ -1066,14 +1055,25 @@
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
             "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/engine.io/node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/engine.io/node_modules/debug": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -1089,7 +1089,8 @@
         "node_modules/engine.io/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/entities": {
             "version": "4.5.0",
@@ -1151,7 +1152,8 @@
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/escodegen": {
             "version": "2.1.0",
@@ -1215,6 +1217,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1264,35 +1267,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/express/node_modules/cookie": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/express/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/finalhandler": {
             "version": "1.3.1",
@@ -1360,6 +1334,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1368,6 +1343,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -1438,12 +1414,14 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "license": "ISC"
         },
         "node_modules/gridstack": {
             "version": "0.6.4",
             "resolved": "https://registry.npmjs.org/gridstack/-/gridstack-0.6.4.tgz",
             "integrity": "sha512-4ToCnneNg5Uw+ms3xHtPVvsNXdvwQhngdlyNgGkARwvooQu+gLL6xkwPqLU59TsZP/LVvofb2QhEuXyh/ocL8w==",
+            "license": "MIT",
             "dependencies": {
                 "jquery": "^1.8 || 2 || 3"
             }
@@ -1491,6 +1469,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
             "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "license": "MIT",
             "dependencies": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
@@ -1517,7 +1496,8 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
         },
         "node_modules/internmap": {
             "version": "2.0.3",
@@ -1538,14 +1518,16 @@
             }
         },
         "node_modules/jquery": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-            "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "license": "MIT"
         },
         "node_modules/jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "license": "MIT",
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -1609,6 +1591,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "license": "MIT",
             "bin": {
                 "mime": "cli.js"
             },
@@ -1620,6 +1603,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1628,6 +1612,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -1638,12 +1623,14 @@
         "node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
         },
         "node_modules/mustache": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
             "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+            "license": "MIT",
             "bin": {
                 "mustache": "bin/mustache"
             }
@@ -1670,6 +1657,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1702,55 +1690,57 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/node-red-contrib-dir2files/-/node-red-contrib-dir2files-0.3.0.tgz",
             "integrity": "sha512-1aO+tcHmPvkAMiQ2yTbxzWO4UME2dX1YGNnjZF7guIbRpVigKRk+aO/kC78irJ1hFrtpcc9I3dh920zV4Bivew==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "fs-extra": "^7.0.1",
                 "path": "^0.12.7"
             }
         },
         "node_modules/node-red-contrib-gpsd": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-gpsd/-/node-red-contrib-gpsd-1.0.7.tgz",
-            "integrity": "sha512-iQoOf+dKj2FaC7oTveNU4i24ap0iejtrlD/gpdo/iX9H95qLDvFwT2Mfbtil+UtycyCtG/2nOn+n03IJ9OtyQQ==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/node-red-contrib-gpsd/-/node-red-contrib-gpsd-1.0.8.tgz",
+            "integrity": "sha512-KLZ2/bVqyt1LD3TbfyjCzN3piR0KGVLt3RlB9vIygyc2ML1J/AyvqYrGS3fWaWtIVK0k+f+NkK6BV/DXO2q/2Q==",
+            "license": "GPL-3.0+",
             "dependencies": {
-                "node-gpsd": "^0.3.0"
+                "node-gpsd": "^0.3.4"
             }
         },
         "node_modules/node-red-contrib-python3-function": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/node-red-contrib-python3-function/-/node-red-contrib-python3-function-0.0.4.tgz",
-            "integrity": "sha512-m7JOWdUQCrX2g7IoCPUlyu1jQt31egYCbGbFenw+nB/28VMtjs9tTYrPxpraPfxU89oQ7XeiiQzq4DWKD3MAKw=="
+            "integrity": "sha512-m7JOWdUQCrX2g7IoCPUlyu1jQt31egYCbGbFenw+nB/28VMtjs9tTYrPxpraPfxU89oQ7XeiiQzq4DWKD3MAKw==",
+            "license": "MIT"
         },
         "node_modules/node-red-contrib-ui-multistate-switch": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/node-red-contrib-ui-multistate-switch/-/node-red-contrib-ui-multistate-switch-1.2.3.tgz",
             "integrity": "sha512-Bh4FiSllZSiVIWv8praWrkIM98noX47oUFQ7jVsFM9VIWA33Rda6QMh+HslT8dpjniSBrVWXBDWkrIVDwWQW8Q==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "mustache": "^4.2.0"
             }
         },
         "node_modules/node-red-dashboard": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/node-red-dashboard/-/node-red-dashboard-3.5.0.tgz",
-            "integrity": "sha512-pTGz/v7MHEUVMXokqV5wrixTyW1SGI5v5ALJkA+p7vTBh4Ho1zjAb7uc63iJkgrSHRuu0S+E1oSb9SbqKeVTCA==",
+            "version": "3.6.5",
+            "resolved": "https://registry.npmjs.org/node-red-dashboard/-/node-red-dashboard-3.6.5.tgz",
+            "integrity": "sha512-zoTVq13lh3OXzxBdFJByxaiijHLOCdkVfR5eCKXNm0RNFfGFyaqPQ06OoeLPXTmhU6KU/VDINxCKJUtdChg9Iw==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "compression": "^1.7.4",
                 "gridstack": "^0.6.4",
                 "serve-static": "^1.15.0",
-                "socket.io": "^4.5.4"
+                "socket.io": "^4.7.4"
             },
             "engines": {
                 "node": ">=12"
             }
         },
-        "node_modules/node-red-node-pi-gpio": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/node-red-node-pi-gpio/-/node-red-node-pi-gpio-2.0.6.tgz",
-            "integrity": "sha512-HffD0XcGARXZuPnnPvGm9oEdWD8lNzYYjQYxjtLbVbZjiC9beU0QaqD0Os7zsXtIXbUsHxXG2YXdGJpvEtqJyg=="
-        },
         "node_modules/node-red-node-ui-list": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/node-red-node-ui-list/-/node-red-node-ui-list-0.3.6.tgz",
             "integrity": "sha512-JoCJEFmLLuRRBeCP0PsqNL8YNNGYFoINnXG/ZzGLe0rovXpEshxLekpy1qR7aJQE5hRa+4KAzGBfoBQQRerUAw==",
+            "license": "Apache-2.0",
             "peerDependencies": {
                 "node-red-dashboard": ">2.15.0"
             }
@@ -1759,6 +1749,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1779,6 +1770,7 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -1790,6 +1782,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
             "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1807,6 +1800,7 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1815,6 +1809,7 @@
             "version": "0.12.7",
             "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
             "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+            "license": "MIT",
             "dependencies": {
                 "process": "^0.11.1",
                 "util": "^0.10.3"
@@ -1879,6 +1874,7 @@
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -1921,6 +1917,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1936,15 +1933,6 @@
                 "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/raw-body/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1974,9 +1962,24 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -1988,6 +1991,7 @@
             "version": "0.19.0",
             "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
             "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -2011,6 +2015,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2018,12 +2023,14 @@
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/serve-static": {
             "version": "1.16.2",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
             "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "license": "MIT",
             "dependencies": {
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
@@ -2037,7 +2044,8 @@
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
@@ -2112,9 +2120,10 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.0.tgz",
-            "integrity": "sha512-8U6BEgGjQOfGz3HHTYaC/L1GaxDCJ/KM0XTkJly0EhZ5U/du9uNEZy4ZgYzEzIqlx2CMm25CrCqr1ck899eLNA==",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+            "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
@@ -2132,17 +2141,19 @@
             "version": "2.5.5",
             "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
             "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "~4.3.4",
                 "ws": "~8.17.1"
             }
         },
         "node_modules/socket.io-adapter/node_modules/debug": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2154,14 +2165,16 @@
             }
         },
         "node_modules/socket.io-adapter/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/socket.io-parser": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
             "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+            "license": "MIT",
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1"
@@ -2171,11 +2184,12 @@
             }
         },
         "node_modules/socket.io-parser/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2187,16 +2201,18 @@
             }
         },
         "node_modules/socket.io-parser/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/socket.io/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2208,9 +2224,10 @@
             }
         },
         "node_modules/socket.io/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -2235,6 +2252,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2248,6 +2266,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.6"
             }
@@ -2266,14 +2285,16 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "license": "MIT"
         },
         "node_modules/universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -2291,6 +2312,7 @@
             "version": "0.10.4",
             "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
             "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+            "license": "MIT",
             "dependencies": {
                 "inherits": "2.0.3"
             }
@@ -2298,7 +2320,8 @@
         "node_modules/util/node_modules/inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+            "license": "ISC"
         },
         "node_modules/utils-merge": {
             "version": "1.0.1",
@@ -2313,6 +2336,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2354,6 +2378,7 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
             "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -2369,1609 +2394,6 @@
                     "optional": true
                 }
             }
-        }
-    },
-    "dependencies": {
-        "@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="
-        },
-        "@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="
-        },
-        "@babel/parser": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-            "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
-            "requires": {
-                "@babel/types": "^7.27.0"
-            }
-        },
-        "@babel/types": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-            "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
-            "requires": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
-            }
-        },
-        "@flowfuse/flow-renderer": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/flow-renderer/-/flow-renderer-0.4.1.tgz",
-            "integrity": "sha512-HQfBUd6bw0extbEgnUv4xjmPF6t+ViIcQAUqxQ7ynnzhJlfuKNnGPmezcGU8rIdKN6zHK/38bbrQIyRCVmI7uw=="
-        },
-        "@flowfuse/node-red-dashboard": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/node-red-dashboard/-/node-red-dashboard-1.22.1.tgz",
-            "integrity": "sha512-3PQN93riBj/u+rcvnPVkFlAeN8PP0OaIbhKrQWd5Un3GDT1fFOR6AFV2CLTToZHqc03YatUWKZxqyh2W1UH2vg==",
-            "requires": {
-                "acorn": "^8.11.2",
-                "axios": "^1.7.7",
-                "chartjs-adapter-luxon": "^1.3.1",
-                "core-js": "^3.32.0",
-                "d3": "^7.8.5",
-                "escodegen": "^2.1.0",
-                "express": "^4.21.2",
-                "socket.io": "^4.7.1",
-                "vue": "^3.4.5"
-            }
-        },
-        "@flowfuse/node-red-dashboard-2-ui-flowviewer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/node-red-dashboard-2-ui-flowviewer/-/node-red-dashboard-2-ui-flowviewer-1.0.1.tgz",
-            "integrity": "sha512-vifliYm0HmmJpnmoV9rX7EbK78YENpQf7xu1MH1AkZCzAalg33i7ojKnWhgvXbpshoU06kC8WR0N6kn5zG7HTw==",
-            "requires": {
-                "@flowfuse/flow-renderer": "^0.4.1",
-                "vue": "^3.3.8",
-                "vuex": "^4.1.0"
-            }
-        },
-        "@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
-        },
-        "@kurkle/color": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-            "peer": true
-        },
-        "@socket.io/component-emitter": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
-        },
-        "@types/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
-        },
-        "@types/cors": {
-            "version": "2.8.17",
-            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
-            "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/node": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-            "requires": {
-                "undici-types": "~6.19.2"
-            }
-        },
-        "@vue/compiler-core": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-            "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-            "requires": {
-                "@babel/parser": "^7.25.3",
-                "@vue/shared": "3.5.13",
-                "entities": "^4.5.0",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.0"
-            }
-        },
-        "@vue/compiler-dom": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
-            "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-            "requires": {
-                "@vue/compiler-core": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/compiler-sfc": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
-            "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
-            "requires": {
-                "@babel/parser": "^7.25.3",
-                "@vue/compiler-core": "3.5.13",
-                "@vue/compiler-dom": "3.5.13",
-                "@vue/compiler-ssr": "3.5.13",
-                "@vue/shared": "3.5.13",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.11",
-                "postcss": "^8.4.48",
-                "source-map-js": "^1.2.0"
-            }
-        },
-        "@vue/compiler-ssr": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
-            "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
-            "requires": {
-                "@vue/compiler-dom": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/devtools-api": {
-            "version": "6.6.4",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-            "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
-        },
-        "@vue/reactivity": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
-            "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
-            "requires": {
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/runtime-core": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
-            "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
-            "requires": {
-                "@vue/reactivity": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/runtime-dom": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
-            "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
-            "requires": {
-                "@vue/reactivity": "3.5.13",
-                "@vue/runtime-core": "3.5.13",
-                "@vue/shared": "3.5.13",
-                "csstype": "^3.1.3"
-            }
-        },
-        "@vue/server-renderer": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
-            "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
-            "requires": {
-                "@vue/compiler-ssr": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "@vue/shared": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="
-        },
-        "accepts": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-            "requires": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
-            }
-        },
-        "acorn": {
-            "version": "8.14.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="
-        },
-        "array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
-        "axios": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-            "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-            "requires": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
-        "base64id": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
-        },
-        "body-parser": {
-            "version": "1.20.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-            "requires": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.13.0",
-                "raw-body": "2.5.2",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "bytes": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                }
-            }
-        },
-        "bytes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
-        },
-        "call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            }
-        },
-        "call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "requires": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            }
-        },
-        "chart.js": {
-            "version": "4.4.8",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
-            "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
-            "peer": true,
-            "requires": {
-                "@kurkle/color": "^0.3.0"
-            }
-        },
-        "chartjs-adapter-luxon": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/chartjs-adapter-luxon/-/chartjs-adapter-luxon-1.3.1.tgz",
-            "integrity": "sha512-yxHov3X8y+reIibl1o+j18xzrcdddCLqsXhriV2+aQ4hCR66IYFchlRXUvrJVoxglJ380pgytU7YWtoqdIgqhg==",
-            "requires": {}
-        },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
-        "commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        },
-        "compressible": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-            "requires": {
-                "mime-db": ">= 1.43.0 < 2"
-            }
-        },
-        "compression": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
-            "requires": {
-                "accepts": "~1.3.5",
-                "bytes": "3.0.0",
-                "compressible": "~2.0.16",
-                "debug": "2.6.9",
-                "on-headers": "~1.0.2",
-                "safe-buffer": "5.1.2",
-                "vary": "~1.1.2"
-            }
-        },
-        "content-disposition": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-            "requires": {
-                "safe-buffer": "5.2.1"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                }
-            }
-        },
-        "content-type": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
-        },
-        "cookie": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-        },
-        "cookie-signature": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-        },
-        "coord-parser": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/coord-parser/-/coord-parser-1.0.0.tgz",
-            "integrity": "sha512-rketzalr6NS1IE8QjVf90djYvfxQ97aL3onUj8VlJsGsEBbsKf6SoKK3awYTrqynLr9VEBbCkHrwayGU4XjU2Q=="
-        },
-        "core-js": {
-            "version": "3.41.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
-            "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA=="
-        },
-        "cors": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-            "requires": {
-                "object-assign": "^4",
-                "vary": "^1"
-            }
-        },
-        "cronosjs": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/cronosjs/-/cronosjs-1.7.1.tgz",
-            "integrity": "sha512-d6S6+ep7dJxsAG8OQQCdKuByI/S/AV64d9OF5mtmcykOyPu92cAkAnF3Tbc9s5oOaLQBYYQmTNvjqYRkPJ/u5Q=="
-        },
-        "cronstrue": {
-            "version": "2.57.0",
-            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.57.0.tgz",
-            "integrity": "sha512-gQOfxJa1RA9uDT4hx37NshhX4dW9t9zTCtIYu15LUziH+mkpuLXYcSEyM8ZewMJ2p8UVuHGjI3n4hGpu3HtCbg=="
-        },
-        "csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "d3": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-            "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-            "requires": {
-                "d3-array": "3",
-                "d3-axis": "3",
-                "d3-brush": "3",
-                "d3-chord": "3",
-                "d3-color": "3",
-                "d3-contour": "4",
-                "d3-delaunay": "6",
-                "d3-dispatch": "3",
-                "d3-drag": "3",
-                "d3-dsv": "3",
-                "d3-ease": "3",
-                "d3-fetch": "3",
-                "d3-force": "3",
-                "d3-format": "3",
-                "d3-geo": "3",
-                "d3-hierarchy": "3",
-                "d3-interpolate": "3",
-                "d3-path": "3",
-                "d3-polygon": "3",
-                "d3-quadtree": "3",
-                "d3-random": "3",
-                "d3-scale": "4",
-                "d3-scale-chromatic": "3",
-                "d3-selection": "3",
-                "d3-shape": "3",
-                "d3-time": "3",
-                "d3-time-format": "4",
-                "d3-timer": "3",
-                "d3-transition": "3",
-                "d3-zoom": "3"
-            }
-        },
-        "d3-array": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-            "requires": {
-                "internmap": "1 - 2"
-            }
-        },
-        "d3-axis": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
-        },
-        "d3-brush": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-            "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "3",
-                "d3-transition": "3"
-            }
-        },
-        "d3-chord": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-            "requires": {
-                "d3-path": "1 - 3"
-            }
-        },
-        "d3-color": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
-        },
-        "d3-contour": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-            "requires": {
-                "d3-array": "^3.2.0"
-            }
-        },
-        "d3-delaunay": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-            "requires": {
-                "delaunator": "5"
-            }
-        },
-        "d3-dispatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
-        },
-        "d3-drag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-            "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-selection": "3"
-            }
-        },
-        "d3-dsv": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-            "requires": {
-                "commander": "7",
-                "iconv-lite": "0.6",
-                "rw": "1"
-            }
-        },
-        "d3-ease": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
-        },
-        "d3-fetch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-            "requires": {
-                "d3-dsv": "1 - 3"
-            }
-        },
-        "d3-force": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-            "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-quadtree": "1 - 3",
-                "d3-timer": "1 - 3"
-            }
-        },
-        "d3-format": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
-        },
-        "d3-geo": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-            "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-            "requires": {
-                "d3-array": "2.5.0 - 3"
-            }
-        },
-        "d3-hierarchy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
-        },
-        "d3-interpolate": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-            "requires": {
-                "d3-color": "1 - 3"
-            }
-        },
-        "d3-path": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
-        },
-        "d3-polygon": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
-        },
-        "d3-quadtree": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
-        },
-        "d3-random": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
-        },
-        "d3-scale": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-            "requires": {
-                "d3-array": "2.10.0 - 3",
-                "d3-format": "1 - 3",
-                "d3-interpolate": "1.2.0 - 3",
-                "d3-time": "2.1.1 - 3",
-                "d3-time-format": "2 - 4"
-            }
-        },
-        "d3-scale-chromatic": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-            "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-            "requires": {
-                "d3-color": "1 - 3",
-                "d3-interpolate": "1 - 3"
-            }
-        },
-        "d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
-        },
-        "d3-shape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-            "requires": {
-                "d3-path": "^3.1.0"
-            }
-        },
-        "d3-time": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-            "requires": {
-                "d3-array": "2 - 3"
-            }
-        },
-        "d3-time-format": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-            "requires": {
-                "d3-time": "1 - 3"
-            }
-        },
-        "d3-timer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
-        },
-        "d3-transition": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-            "requires": {
-                "d3-color": "1 - 3",
-                "d3-dispatch": "1 - 3",
-                "d3-ease": "1 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-timer": "1 - 3"
-            }
-        },
-        "d3-zoom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-            "requires": {
-                "d3-dispatch": "1 - 3",
-                "d3-drag": "2 - 3",
-                "d3-interpolate": "1 - 3",
-                "d3-selection": "2 - 3",
-                "d3-transition": "2 - 3"
-            }
-        },
-        "debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "requires": {
-                "ms": "2.0.0"
-            }
-        },
-        "delaunator": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-            "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-            "requires": {
-                "robust-predicates": "^3.0.2"
-            }
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-        },
-        "depd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        },
-        "destroy": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
-        },
-        "dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "requires": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            }
-        },
-        "ee-first": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-        },
-        "encodeurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
-        },
-        "engine.io": {
-            "version": "6.6.2",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
-            "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
-            "requires": {
-                "@types/cookie": "^0.4.1",
-                "@types/cors": "^2.8.12",
-                "@types/node": ">=10.0.0",
-                "accepts": "~1.3.4",
-                "base64id": "2.0.0",
-                "cookie": "~0.7.2",
-                "cors": "~2.8.5",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.17.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-                    "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-                    "requires": {
-                        "ms": "^2.1.3"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-                }
-            }
-        },
-        "engine.io-parser": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
-        },
-        "entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
-        },
-        "es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-        },
-        "es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-        },
-        "es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "requires": {
-                "es-errors": "^1.3.0"
-            }
-        },
-        "es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            }
-        },
-        "escape-html": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-        },
-        "escodegen": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "requires": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2",
-                "source-map": "~0.6.1"
-            }
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
-        "estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        },
-        "estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-        },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-        },
-        "etag": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-        },
-        "express": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-            "requires": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.3",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.7.1",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.3.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.13.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.19.0",
-                "serve-static": "1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "dependencies": {
-                "cookie": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-                    "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                }
-            }
-        },
-        "finalhandler": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-            "requires": {
-                "debug": "2.6.9",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "2.0.1",
-                "unpipe": "~1.0.0"
-            }
-        },
-        "follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
-        },
-        "form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "mime-types": "^2.1.12"
-            }
-        },
-        "forwarded": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
-        },
-        "fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
-        },
-        "fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            }
-        },
-        "function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-        },
-        "get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "requires": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            }
-        },
-        "get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "requires": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            }
-        },
-        "gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-        },
-        "graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-        },
-        "gridstack": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/gridstack/-/gridstack-0.6.4.tgz",
-            "integrity": "sha512-4ToCnneNg5Uw+ms3xHtPVvsNXdvwQhngdlyNgGkARwvooQu+gLL6xkwPqLU59TsZP/LVvofb2QhEuXyh/ocL8w==",
-            "requires": {
-                "jquery": "^1.8 || 2 || 3"
-            }
-        },
-        "has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-        },
-        "has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "requires": {
-                "has-symbols": "^1.0.3"
-            }
-        },
-        "hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "requires": {
-                "function-bind": "^1.1.2"
-            }
-        },
-        "http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-            "requires": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            }
-        },
-        "iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "internmap": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
-        },
-        "ipaddr.js": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-        },
-        "jquery": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-            "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
-        },
-        "jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "requires": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "luxon": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
-            "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
-            "peer": true
-        },
-        "magic-string": {
-            "version": "0.30.17",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-            "requires": {
-                "@jridgewell/sourcemap-codec": "^1.5.0"
-            }
-        },
-        "math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-        },
-        "media-typer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
-        },
-        "merge-descriptors": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
-        },
-        "methods": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
-        },
-        "mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-        },
-        "mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "requires": {
-                "mime-db": "1.52.0"
-            }
-        },
-        "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        },
-        "mustache": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-            "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
-        },
-        "nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
-        },
-        "negotiator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-        },
-        "node-gpsd": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/node-gpsd/-/node-gpsd-0.3.4.tgz",
-            "integrity": "sha512-sI9hPfHiaWDmhjE1oJZnhMo7UF2vQVGl3qk0K4HbN1L8BkS0I+rd6V687eHOj/6ervXiHrhwXzYYsWdXxGy0Qg=="
-        },
-        "node-red-contrib-cron-plus": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-cron-plus/-/node-red-contrib-cron-plus-2.1.0.tgz",
-            "integrity": "sha512-qiEvEpnQgFdjEX5PBv8CXt/kJEIbuf0D0rhxr3S0pcup6Jb1r4GhGsBHvkdzxheLOIDnzS1GlGBYYUGgU+5smQ==",
-            "requires": {
-                "coord-parser": "^1.0.0",
-                "cronosjs": "^1.7.1",
-                "cronstrue": "^2.28.0",
-                "pretty-ms": "7.0.1",
-                "suncalc2": "^1.8.1"
-            }
-        },
-        "node-red-contrib-dir2files": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-dir2files/-/node-red-contrib-dir2files-0.3.0.tgz",
-            "integrity": "sha512-1aO+tcHmPvkAMiQ2yTbxzWO4UME2dX1YGNnjZF7guIbRpVigKRk+aO/kC78irJ1hFrtpcc9I3dh920zV4Bivew==",
-            "requires": {
-                "fs-extra": "^7.0.1",
-                "path": "^0.12.7"
-            }
-        },
-        "node-red-contrib-gpsd": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-gpsd/-/node-red-contrib-gpsd-1.0.7.tgz",
-            "integrity": "sha512-iQoOf+dKj2FaC7oTveNU4i24ap0iejtrlD/gpdo/iX9H95qLDvFwT2Mfbtil+UtycyCtG/2nOn+n03IJ9OtyQQ==",
-            "requires": {
-                "node-gpsd": "^0.3.0"
-            }
-        },
-        "node-red-contrib-python3-function": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-python3-function/-/node-red-contrib-python3-function-0.0.4.tgz",
-            "integrity": "sha512-m7JOWdUQCrX2g7IoCPUlyu1jQt31egYCbGbFenw+nB/28VMtjs9tTYrPxpraPfxU89oQ7XeiiQzq4DWKD3MAKw=="
-        },
-        "node-red-contrib-ui-multistate-switch": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-ui-multistate-switch/-/node-red-contrib-ui-multistate-switch-1.2.3.tgz",
-            "integrity": "sha512-Bh4FiSllZSiVIWv8praWrkIM98noX47oUFQ7jVsFM9VIWA33Rda6QMh+HslT8dpjniSBrVWXBDWkrIVDwWQW8Q==",
-            "requires": {
-                "mustache": "^4.2.0"
-            }
-        },
-        "node-red-dashboard": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/node-red-dashboard/-/node-red-dashboard-3.5.0.tgz",
-            "integrity": "sha512-pTGz/v7MHEUVMXokqV5wrixTyW1SGI5v5ALJkA+p7vTBh4Ho1zjAb7uc63iJkgrSHRuu0S+E1oSb9SbqKeVTCA==",
-            "requires": {
-                "compression": "^1.7.4",
-                "gridstack": "^0.6.4",
-                "serve-static": "^1.15.0",
-                "socket.io": "^4.5.4"
-            }
-        },
-        "node-red-node-pi-gpio": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/node-red-node-pi-gpio/-/node-red-node-pi-gpio-2.0.6.tgz",
-            "integrity": "sha512-HffD0XcGARXZuPnnPvGm9oEdWD8lNzYYjQYxjtLbVbZjiC9beU0QaqD0Os7zsXtIXbUsHxXG2YXdGJpvEtqJyg=="
-        },
-        "node-red-node-ui-list": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/node-red-node-ui-list/-/node-red-node-ui-list-0.3.6.tgz",
-            "integrity": "sha512-JoCJEFmLLuRRBeCP0PsqNL8YNNGYFoINnXG/ZzGLe0rovXpEshxLekpy1qR7aJQE5hRa+4KAzGBfoBQQRerUAw==",
-            "requires": {}
-        },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-        },
-        "object-inspect": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
-        },
-        "on-finished": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-            "requires": {
-                "ee-first": "1.1.1"
-            }
-        },
-        "on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
-        },
-        "parse-ms": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-            "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
-        },
-        "parseurl": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-        },
-        "path": {
-            "version": "0.12.7",
-            "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-            "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-            "requires": {
-                "process": "^0.11.1",
-                "util": "^0.10.3"
-            }
-        },
-        "path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
-        },
-        "picocolors": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
-        },
-        "postcss": {
-            "version": "8.5.3",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
-            "requires": {
-                "nanoid": "^3.3.8",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "pretty-ms": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-            "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
-            "requires": {
-                "parse-ms": "^2.1.0"
-            }
-        },
-        "process": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
-        },
-        "proxy-addr": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-            "requires": {
-                "forwarded": "0.2.0",
-                "ipaddr.js": "1.9.1"
-            }
-        },
-        "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
-        "qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-            "requires": {
-                "side-channel": "^1.0.6"
-            }
-        },
-        "range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-        },
-        "raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-            "requires": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "bytes": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                }
-            }
-        },
-        "robust-predicates": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
-        },
-        "rw": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-            "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
-        },
-        "safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "send": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-            "requires": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
-            },
-            "dependencies": {
-                "encodeurl": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-                    "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-                }
-            }
-        },
-        "serve-static": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-            "requires": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.19.0"
-            }
-        },
-        "setprototypeof": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-        },
-        "side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
-                "side-channel-map": "^1.0.1",
-                "side-channel-weakmap": "^1.0.2"
-            }
-        },
-        "side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
-            }
-        },
-        "side-channel-map": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3"
-            }
-        },
-        "side-channel-weakmap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3",
-                "side-channel-map": "^1.0.1"
-            }
-        },
-        "socket.io": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.0.tgz",
-            "integrity": "sha512-8U6BEgGjQOfGz3HHTYaC/L1GaxDCJ/KM0XTkJly0EhZ5U/du9uNEZy4ZgYzEzIqlx2CMm25CrCqr1ck899eLNA==",
-            "requires": {
-                "accepts": "~1.3.4",
-                "base64id": "~2.0.0",
-                "cors": "~2.8.5",
-                "debug": "~4.3.2",
-                "engine.io": "~6.6.0",
-                "socket.io-adapter": "~2.5.2",
-                "socket.io-parser": "~4.2.4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
-            }
-        },
-        "socket.io-adapter": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-            "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-            "requires": {
-                "debug": "~4.3.4",
-                "ws": "~8.17.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.5",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-                    "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
-            }
-        },
-        "socket.io-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-            "requires": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
-            }
-        },
-        "source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "optional": true
-        },
-        "source-map-js": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
-        },
-        "statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-        },
-        "suncalc2": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/suncalc2/-/suncalc2-1.8.1.tgz",
-            "integrity": "sha512-tNoAni1LqWzBzJRX3NRCsD50gVsuejH1jd9Y+XyKO3WkpPIU+QNyWF4Zf2JnUQKW2LKLWIBgVDQCrgsQwqs0tA=="
-        },
-        "toidentifier": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-        },
-        "type-is": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-            "requires": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
-            }
-        },
-        "undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-        },
-        "universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-        },
-        "unpipe": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
-        },
-        "util": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-            "requires": {
-                "inherits": "2.0.3"
-            },
-            "dependencies": {
-                "inherits": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
-                }
-            }
-        },
-        "utils-merge": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
-        },
-        "vary": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-        },
-        "vue": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
-            "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
-            "requires": {
-                "@vue/compiler-dom": "3.5.13",
-                "@vue/compiler-sfc": "3.5.13",
-                "@vue/runtime-dom": "3.5.13",
-                "@vue/server-renderer": "3.5.13",
-                "@vue/shared": "3.5.13"
-            }
-        },
-        "vuex": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
-            "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
-            "requires": {
-                "@vue/devtools-api": "^6.0.0-beta.11"
-            }
-        },
-        "ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-            "requires": {}
         }
     }
 }

--- a/software/node-red-dashboard/planktoscopehat/package.json
+++ b/software/node-red-dashboard/planktoscopehat/package.json
@@ -11,7 +11,6 @@
         "node-red-contrib-python3-function": "^0.0.4",
         "node-red-contrib-ui-multistate-switch": "^1.2.2",
         "node-red-dashboard": "^3.1.2",
-        "node-red-node-pi-gpio": "^2.0.1",
         "node-red-node-ui-list": "^0.3.6"
     },
     "node-red": {


### PR DESCRIPTION
Fixes https://github.com/PlanktoScope/PlanktoScope/issues/322

**planktoscopehat**

This can be safely removed as documented in https://github.com/PlanktoScope/PlanktoScope/issues/322#issuecomment-2809367966

It also fixes this nodered log spamming every 5s

`Apr 17 11:22:22 pkscope-secret-authority-46635 Node-RED[124382]: 17 Apr 11:22:22 - [error] [rpi-gpio out:Fan] nrgpio python command not running`

**adafruithat**

The `flows.json` file was left untouched.

---

Besides the removed package, `package-lock.json` was updated by `npm update` and staged to remove several unused dependencies.

I used https://github.com/PlanktoScope/PlanktoScope/pull/573 to perform this update.