### PR TITLE
Remove stepper_type

### DIFF
--- a/device-backend/default-configs/adafruithat-latest.hardware.json
+++ b/device-backend/default-configs/adafruithat-latest.hardware.json
@@ -5,7 +5,6 @@
   "pump_steps_per_ml": 507,
   "focus_max_speed": 0.5,
   "pump_max_speed": 30,
-  "stepper_type": "adafruit",
   "red_gain": 2,
   "blue_gain": 1.41,
   "analog_gain": 1.0,

--- a/device-backend/default-configs/fairscope-latest.hardware.json
+++ b/device-backend/default-configs/fairscope-latest.hardware.json
@@ -5,7 +5,6 @@
   "pump_steps_per_ml": 2045,
   "focus_max_speed": 5,
   "pump_max_speed": 50,
-  "stepper_type": "pscope_hat",
   "red_gain": 2.4,
   "blue_gain": 1.35,
   "analog_gain": 1.0,

--- a/device-backend/default-configs/planktoscopehat-latest.hardware.json
+++ b/device-backend/default-configs/planktoscopehat-latest.hardware.json
@@ -5,7 +5,6 @@
   "pump_steps_per_ml": 2045,
   "focus_max_speed": 5,
   "pump_max_speed": 50,
-  "stepper_type": "pscope_hat",
   "red_gain": 2.4,
   "blue_gain": 1.35,
   "analog_gain": 1.0,

--- a/device-backend/default-configs/v2.1.hardware.json
+++ b/device-backend/default-configs/v2.1.hardware.json
@@ -5,7 +5,6 @@
   "pump_steps_per_ml": 507,
   "focus_max_speed": 0.5,
   "pump_max_speed": 30,
-  "stepper_type": "adafruit",
   "red_gain": 2,
   "blue_gain": 1.41,
   "analog_gain": 1.0,

--- a/device-backend/default-configs/v2.3.hardware.json
+++ b/device-backend/default-configs/v2.3.hardware.json
@@ -5,7 +5,6 @@
   "pump_steps_per_ml": 3200,
   "focus_max_speed": 5,
   "pump_max_speed": 50,
-  "stepper_type": "pscope_hat",
   "red_gain": 2,
   "blue_gain": 1.41,
   "analog_gain": 1.0,

--- a/device-backend/default-configs/v2.5.hardware.json
+++ b/device-backend/default-configs/v2.5.hardware.json
@@ -5,7 +5,6 @@
   "pump_steps_per_ml": 2045,
   "focus_max_speed": 5,
   "pump_max_speed": 50,
-  "stepper_type": "pscope_hat",
   "red_gain": 2.4,
   "blue_gain": 1.35,
   "analog_gain": 1.0,

--- a/device-backend/default-configs/v2.6.hardware.json
+++ b/device-backend/default-configs/v2.6.hardware.json
@@ -5,7 +5,6 @@
   "pump_steps_per_ml": 2045,
   "focus_max_speed": 5,
   "pump_max_speed": 50,
-  "stepper_type": "pscope_hat",
   "red_gain": 2.4,
   "blue_gain": 1.35,
   "analog_gain": 1.0,

--- a/device-backend/default-configs/v3.0.hardware.json
+++ b/device-backend/default-configs/v3.0.hardware.json
@@ -5,7 +5,6 @@
   "pump_steps_per_ml": 2045,
   "focus_max_speed": 5,
   "pump_max_speed": 50,
-  "stepper_type": "pscope_hat",
   "red_gain": 2.4,
   "blue_gain": 1.35,
   "analog_gain": 1.0,

--- a/software/node-red-dashboard/adafruithat/flows.json
+++ b/software/node-red-dashboard/adafruithat/flows.json
@@ -8382,82 +8382,6 @@
         "wires": []
     },
     {
-        "id": "e10f5e55.00b828",
-        "type": "change",
-        "z": "1eaf21c8.f7a21e",
-        "name": "Get stepper_type",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "payload.stepper_type",
-                "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 630,
-        "y": 360,
-        "wires": [
-            [
-                "dee52a36.2af72"
-            ]
-        ]
-    },
-    {
-        "id": "dee52a36.2af72",
-        "type": "ui_dropdown",
-        "z": "1eaf21c8.f7a21e",
-        "name": "stepper_type",
-        "label": "",
-        "tooltip": "",
-        "place": "",
-        "group": "6be36295.0ab324",
-        "order": 4,
-        "width": 3,
-        "height": 1,
-        "passthru": false,
-        "multiple": false,
-        "options": [
-            {
-                "label": "",
-                "value": "adafruit",
-                "type": "str"
-            },
-            {
-                "label": "",
-                "value": "waveshare",
-                "type": "str"
-            },
-            {
-                "label": "",
-                "value": "waveshareRev2.1",
-                "type": "str"
-            },
-            {
-                "label": "",
-                "value": "pscope_hat",
-                "type": "str"
-            }
-        ],
-        "payload": "",
-        "topic": "stepper_type",
-        "topicType": "str",
-        "className": "",
-        "x": 950,
-        "y": 360,
-        "wires": [
-            [
-                "2068e7f.f4efb18",
-                "8e3b3d3c.955148"
-            ]
-        ]
-    },
-    {
         "id": "e41870d7.300eb8",
         "type": "link out",
         "z": "1eaf21c8.f7a21e",
@@ -8960,7 +8884,6 @@
             [
                 "c534fd26.13741",
                 "54ba7f16.709ad8",
-                "e10f5e55.00b828",
                 "c67c305004f87e39",
                 "11955bbeefc29ab4"
             ]

--- a/software/node-red-dashboard/planktoscopehat/flows.json
+++ b/software/node-red-dashboard/planktoscopehat/flows.json
@@ -8244,77 +8244,6 @@
         "wires": []
     },
     {
-        "id": "e10f5e55.00b828",
-        "type": "change",
-        "z": "1eaf21c8.f7a21e",
-        "name": "Get stepper_type",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "payload.stepper_type",
-                "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 650,
-        "y": 360,
-        "wires": [
-            [
-                "dee52a36.2af72"
-            ]
-        ]
-    },
-    {
-        "id": "dee52a36.2af72",
-        "type": "ui_dropdown",
-        "z": "1eaf21c8.f7a21e",
-        "name": "stepper_type",
-        "label": "",
-        "tooltip": "",
-        "place": "",
-        "group": "6be36295.0ab324",
-        "order": 4,
-        "width": 3,
-        "height": 1,
-        "passthru": false,
-        "multiple": false,
-        "options": [
-            {
-                "label": "",
-                "value": "adafruit",
-                "type": "str"
-            },
-            {
-                "label": "",
-                "value": "waveshare",
-                "type": "str"
-            },
-            {
-                "label": "",
-                "value": "pscope_hat",
-                "type": "str"
-            }
-        ],
-        "payload": "",
-        "topic": "stepper_type",
-        "topicType": "str",
-        "className": "",
-        "x": 970,
-        "y": 360,
-        "wires": [
-            [
-                "2068e7f.f4efb18",
-                "8e3b3d3c.955148"
-            ]
-        ]
-    },
-    {
         "id": "e41870d7.300eb8",
         "type": "link out",
         "z": "1eaf21c8.f7a21e",
@@ -8930,7 +8859,6 @@
         "y": 440,
         "wires": [
             [
-                "e10f5e55.00b828",
                 "54ba7f16.709ad8",
                 "c534fd26.13741",
                 "c67c305004f87e39",


### PR DESCRIPTION
* Drops Waveshare stepper HAT support
* Removes `stepper_type` as it becomes unused

None of the config uses the Waveshare stepper HAT.

As mentioned in the "Removed" section of [the changelog for v2023.9.0-beta.0](https://github.com/PlanktoScope/PlanktoScope/blob/master/software/CHANGELOG.md#v202390-beta0---2023-09-02), the waveshare HAT is no longer supported by PlanktoScope OS. This is because the PlanktoScope project never took responsibility for waveshare HAT support (see the [2023-05-11 software meeting](https://docs.google.com/document/d/1Vkztzu8rq56b6LRmrgvBiaXGfiq1MTneUzhKl90z7f4/edit?tab=t.0#heading=h.k66wgcoq5ae) notes for details) - it was instead an unmaintained drive-by contribution.