### PR TITLE
Enable RTC battery charging

### DIFF
--- a/software/distro/setup/planktoscope-app-env/PlanktoScope/config.txt.snippet
+++ b/software/distro/setup/planktoscope-app-env/PlanktoScope/config.txt.snippet
@@ -1,19 +1,7 @@
 
-# Start of PlanktoScope configuration
-
-# Enable overclocking
-# Overclocking is supposed to improve the speed of the image segmentation process, though the exact
-# decrease in battery time (or decrease in battery life when segmentation is not running) has not
-# yet been rigorously measured and reported.
-[pi4]
-over_voltage=6
-arm_freq=2000
-
 # Enable battery charging
 # https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#enable-battery-charging
 [pi5]
 dtparam=rtc_bbat_vchg=3000000
 
 [all]
-
-# End of PlanktoScope configuration

--- a/software/distro/setup/planktoscope-app-env/overclocking/boot/config.txt.snippet
+++ b/software/distro/setup/planktoscope-app-env/overclocking/boot/config.txt.snippet
@@ -1,0 +1,6 @@
+
+# PlanktoScope - Enable overclocking
+[pi4]
+over_voltage=6
+arm_freq=2000
+[all]

--- a/software/distro/setup/planktoscope-app-env/overclocking/config.sh
+++ b/software/distro/setup/planktoscope-app-env/overclocking/config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eux
+# Overclocking is supposed to improve the speed of the image segmentation process, though the exact
+# decrease in battery time (or decrease in battery life when segmentation is not running) has not
+# yet been rigorously measured and reported.
+
+# Determine the base path for copied files
+config_files_root=$(dirname $(realpath $BASH_SOURCE))
+
+# Overvoltage to 6 and set clock speed to 2 GHz, for a V_core of 1.0125, a maximum allowable
+# temperature of 72 deg C, a power draw of 11 Watt, and a performance increase of 33%.
+file="/boot/config.txt"
+sudo bash -c "cat \"$config_files_root$file.snippet\" >> \"$file\""


### PR DESCRIPTION
The PlanktoScope v3 includes RTC and a suitable battery.

https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#real-time-clock-rtc