### PR TITLE
Fix regression in hardware controller module imports

### DIFF
--- a/device-backend/control/adafruithat/main.py
+++ b/device-backend/control/adafruithat/main.py
@@ -24,7 +24,7 @@ import os
 from loguru import logger  # for logging with multiprocessing
 
 from adafruithat.planktoscope import stepper, light, identity
-from adafruit.planktoscope.display import Display
+from adafruithat.planktoscope.display import Display
 from adafruithat.planktoscope.imager import mqtt as imager
 
 logger.info("Starting the PlanktoScope hardware controller!")


### PR DESCRIPTION
This PR fixes a regression caused by #617 which broke one of the adafruithat `main.py`'s imports of other modules.