### PR TITLE
Update eeprom

### DIFF
--- a/os/bootloader/install.sh
+++ b/os/bootloader/install.sh
@@ -9,10 +9,10 @@ config_files_root="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 sudo -E apt-get install -y -o Dpkg::Progress-Fancy=0 \
   rpi-eeprom
 
-cp /usr/lib/firmware/raspberrypi/bootloader-2712/latest/pieeprom-2025-03-19.bin /tmp
+cp /usr/lib/firmware/raspberrypi/bootloader-2712/latest/pieeprom-2025-07-17.bin /tmp
 cp /usr/lib/firmware/raspberrypi/bootloader-2712/latest/recovery.bin /tmp
 
-rpi-eeprom-config /tmp/pieeprom-2025-03-19.bin --config "$config_files_root/boot.conf" --out /tmp/pieeprom.upd
+rpi-eeprom-config /tmp/pieeprom-2025-07-17.bin --config "$config_files_root/boot.conf" --out /tmp/pieeprom.upd
 rpi-eeprom-digest -i /tmp/pieeprom.upd -o /tmp/pieeprom.sig
 
 sudo cp /tmp/pieeprom.upd /tmp/pieeprom.sig /tmp/recovery.bin /boot/firmware/


### PR DESCRIPTION
`pieeprom-2025-03-19.bin` does not exist anymore and releases since then bring several benefits.

```
+ cp /usr/lib/firmware/raspberrypi/bootloader-2712/latest/pieeprom-2025-03-19.bin /tmp
cp: cannot stat '/usr/lib/firmware/raspberrypi/bootloader-2712/latest/pieeprom-2025-03-19.bin': No such file or directory
+ panic 'update and configure bootloader'
+ echo -e '\e[1;31mError: couldn'\''t update and configure bootloader\e[0m'
Error: couldn't update and configure bootloader
+ exit 1
Container raspberrypi failed with error code 1.
Error: Process completed with exit code 1.
```

Once a new RPI OS is released we can stop updating `rpi-eeprom` and rely on what's on the base os.