### PR TITLE
os: Do not set wifi country to US

### DIFF
--- a/os/network/justfile
+++ b/os/network/justfile
@@ -7,14 +7,16 @@ setup:
     sudo cp wlan0-hotspot.ini /etc/NetworkManager/system-connections/wlan0-hotspot.nmconnection
     # "failed to load connection: File permissions (100644) are insecure"
     sudo chmod 0600 /etc/NetworkManager/system-connections/wlan0-hotspot.nmconnection
+
     # By default we are greeted with
     # "Wi-Fi is currently blocked by rfkill.
     # Enable wifi, country is unset, user will set it.
     # See https://github.com/RPi-Distro/raspberrypi-net-mods/blob/master/etc/profile.d/wifi-check.sh
     sudo rm -f /etc/profile.d/wifi-check.sh
 
-    # Enable wifi by default
-    sudo cp wifi.sh /etc/profile.d
+    # Enable wifi by default without selecting a country (will use global)
+    sudo cp org-planktoscope.firstboot-wifi.service /etc/systemd/system/
+    sudo systemctl enable org-planktoscope.firstboot-wifi.service
 
     wget https://github.com/grishy/go-avahi-cname/releases/download/v2.2.5/go-avahi-cname_2.2.5_linux_arm64.tar.gz -P /tmp
     cd /tmp && tar -xzf /tmp/go-avahi-cname_2.2.5_linux_arm64.tar.gz go-avahi-cname

--- a/os/network/org-planktoscope.firstboot-wifi.service
+++ b/os/network/org-planktoscope.firstboot-wifi.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Enable wifi on firstboot
+ConditionFirstBoot=yes
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=sh -c "nmcli radio wifi on"
+
+[Install]
+WantedBy=sysinit.target

--- a/os/network/wifi.sh
+++ b/os/network/wifi.sh
@@ -1,1 +1,0 @@
-nmcli radio wifi on


### PR DESCRIPTION
* Do not set wifi country to US
* Enable wifi even though wifi country is not set (will use global)

Users will set their country on dashboard setup/config.