### PR TITLE
os: Remove /run/machine-name

### DIFF
--- a/controller/imager/test.js
+++ b/controller/imager/test.js
@@ -2,7 +2,7 @@ import { Temporal } from "@js-temporal/polyfill"
 
 import { getHardwareVersion } from "../../lib/hardware.js"
 import { getSoftwareVersioning } from "../../lib/software.js"
-import { getName } from "../../lib/identity.js"
+import { getMachineName } from "../../lib/identity.js"
 import {
   acquire,
   configure,
@@ -20,7 +20,7 @@ watch("status/imager").then(async (messages) => {
 })
 
 const hardware_version = await getHardwareVersion()
-const machine_name = await getName()
+const machine_name = await getMachineName()
 const software = await getSoftwareVersioning()
 
 const local_datetime = Temporal.Now.plainDateTimeISO().toString()

--- a/frontend/src/pages/about.data.js
+++ b/frontend/src/pages/about.data.js
@@ -1,4 +1,5 @@
 import { createAsync, query } from "@solidjs/router"
+import { getMachineName } from "../../../lib/identity"
 
 function wait(ms, data) {
   return new Promise((resolve) => setTimeout(resolve, ms, data))
@@ -11,7 +12,7 @@ function random(min, max) {
 const getName = query(() => wait(random(500, 1000), "Solid"), "aboutName")
 
 const AboutData = () => {
-  return createAsync(() => getName())
+  return createAsync(() => getMachineName())
 }
 
 export default AboutData

--- a/lib/hardware.js
+++ b/lib/hardware.js
@@ -1,6 +1,6 @@
 import child_process from "child_process"
 import { promisify } from "util"
-import { getName, getHostname } from "./identity.js"
+import { getMachineName, getHostname } from "./identity.js"
 import { initConfigFiles, readSoftwareConfig } from "./file-config.js"
 import { Systemctl } from "systemctl.js"
 import { getSoftwareVersion } from "./software.js"
@@ -101,7 +101,7 @@ export async function getMachineInfo() {
   const [hardware_version, machine_name, hostname, eeprom, software_version] =
     await Promise.all([
       getHardwareVersion(),
-      getName(),
+      getMachineName(),
       getHostname(),
       readEEPROM().catch(() => {}),
       getSoftwareVersion(),

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -1,21 +1,11 @@
-import { readFile } from "fs/promises"
-import child_process from "child_process"
-import { promisify } from "util"
+import { hostname } from "os"
 
-const execFile = promisify(child_process.execFile)
-
-const path = "/run/machine-name"
-
-export async function getName() {
-  const data = await readFile(path, {
-    encoding: "utf8",
-  })
-
-  return data.trim()
+const prefix = "planktoscope-"
+export function getMachineName() {
+  const hostname = getHostname()
+  return hostname.startsWith(prefix) ? hostname.slice(prefix.length) : hostname
 }
 
-export async function getHostname() {
-  const { stdout } = await execFile("hostnamectl", ["hostname"])
-
-  return stdout.trim()
+export function getHostname() {
+  return hostname()
 }

--- a/node-red/nodes/get-name.js
+++ b/node-red/nodes/get-name.js
@@ -1,11 +1,11 @@
-import { getName } from "../../lib/identity.js"
+import { getMachineName } from "../../lib/identity.js"
 
 export default function (RED) {
   function Node(config) {
     RED.nodes.createNode(this, config)
     const node = this
     node.on("input", function (msg, send, done) {
-      getName()
+      getMachineName()
         .then((name) => {
           msg.payload ??= {}
           Object.assign(msg.payload, { name })


### PR DESCRIPTION
Remove non standard `/run/machine-name`.

If a PlanktoScope hostname is `planktoscope-sponge-bob` we can read its "machine name" by removing the `planktoscope-` prefix. 