### PR TITLE
controller: Use ramp mode for Bubbler

### DIFF
--- a/controller/bubbler/README.md
+++ b/controller/bubbler/README.md
@@ -31,9 +31,6 @@ just dev
 ```json
 {
   "action": "on",
-  // float between 0 and 1
-  // 0 is same as "action": "off"
-  "value": 0.5,
 }
 ```
 
@@ -56,7 +53,6 @@ just dev
 ```json
 {
   "status": "On",
-  "value": 0.5,
 }
 ```
 

--- a/controller/bubbler/main.py
+++ b/controller/bubbler/main.py
@@ -63,7 +63,7 @@ async def handle_action(action: str, payload) -> None:
     assert bubbler is not None
 
     if action == "on":
-        await on(payload)
+        await on()
     elif action == "off":
         await off()
     # elif action == "settings":
@@ -84,7 +84,7 @@ async def handle_action(action: str, payload) -> None:
 #         bubbler.set_current(current)
 
 
-async def on(payload) -> None:
+async def on() -> None:
     global ramp_task
     assert bubbler is not None
 
@@ -95,13 +95,6 @@ async def on(payload) -> None:
         except asyncio.CancelledError:
             pass
         ramp_task = None
-
-    value = payload.get("value", 1)
-    assert 0.0 <= value <= 1.0
-
-    if value == 0:
-        await off()
-        return
 
     # Start ramp mode
     ramp_task = asyncio.create_task(run_ramp())

--- a/controller/bubbler/test.js
+++ b/controller/bubbler/test.js
@@ -9,6 +9,6 @@ watch("status/bubbler").then(async (messages) => {
 
 await startBubbler()
 
-await setTimeout(2000)
+await setTimeout(4000)
 
 await stopBubbler()

--- a/frontend/src/pages/preview/index.jsx
+++ b/frontend/src/pages/preview/index.jsx
@@ -2,7 +2,12 @@ import Stream from "./Stream.jsx"
 
 import styles from "./styles.module.css"
 import "./reader.js"
-import { startLight, startBubbler, watch } from "../../../../lib/scope.js"
+import {
+  startLight,
+  startBubbler,
+  watch,
+  stopBubbler,
+} from "../../../../lib/scope.js"
 import { triggerDownload } from "../../helpers.js"
 
 import cameraIcon from "./camera.svg"
@@ -11,14 +16,12 @@ import NumberInput from "./NumberInput.jsx"
 import { createSignal } from "solid-js"
 
 export default function Preview() {
-  const [bubbler_dac, setBubblerDac] = createSignal(0)
+  const [bubbler, setBubbler] = createSignal(false)
   const [light_dac, setLightDac] = createSignal(0)
 
   watch("status/bubbler").then(async (messages) => {
     for await (const message of messages) {
-      if (message.dac) {
-        setBubblerDac(message.dac)
-      }
+      setBubbler(message.status === "On")
     }
   })
 
@@ -43,11 +46,13 @@ export default function Preview() {
         </div>
         <div>
           <h2>Bubbler</h2>
-          <NumberInput
-            name="bubler"
-            value={bubbler_dac}
+          <label for="bubbler">On/Off</label>
+          <input
+            type="checkbox"
+            name="bubbler"
+            checked={bubbler}
             onChange={onBubblerChange}
-          />
+          ></input>
         </div>
       </div>
       <div class={styles.preview}>
@@ -87,8 +92,10 @@ function onLightChange(value) {
   })
 }
 
-function onBubblerChange(value) {
-  startBubbler({
-    value,
-  })
+function onBubblerChange(event) {
+  if (event.target.checked === true) {
+    startBubbler()
+  } else {
+    stopBubbler()
+  }
 }


### PR DESCRIPTION
## Summary                                                                                                             
  - Implements ramp-based bubbler control for gentle, consistent sample agitation                                        
  - Motor cycles through voltage levels (0.26 → 0.275 → off → pause → repeat)                                            
  - Solves motor stall issues at low voltages and provides smoother operation                                            
  - Adds configurable parameters: RAMP_VALUES, RAMP_STEP_TIME, PAUSE_TIME                                                
                                                                                                                      
  ## Tested with the following:                                                                                                  
  - [ ] Start bubbler with `mosquitto_pub -h localhost -t 'actuator/bubbler' -m '{"action":"on"}'`                       
  - [ ] Verify smooth ramp cycling behavior                                                                              
  - [ ] Verify motor doesn't stall                                                                                       
  - [ ] Stopped with `mosquitto_pub -h localhost -t 'actuator/bubbler' -m '{"action":"off"}'`                               
  - [ ] RAMP_VALUES can be adjusted in main.py if somebody wants to perfect action   