### PR TITLE
lib: Fix listing large segmentations

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -6,7 +6,6 @@ import {
   constants,
   readdir,
   stat,
-  open,
 } from "fs/promises"
 import { parse } from "csv-parse"
 import { createReadStream } from "fs"


### PR DESCRIPTION
The Node-RED Node.js process would run out of memory because we buffer the entire TSV files in memory. 

Instead, only read to the first TSV row for metadatas and count the number of image files for object counts.