### PR TITLE
imager: add pause/resume API

### DIFF
--- a/controller/imager/main.py
+++ b/controller/imager/main.py
@@ -121,6 +121,10 @@ class Imager:
         elif action == "stop" and self._active_routine is not None:
             self._active_routine.stop()
             self._active_routine = None
+        elif action == "pause" and self._active_routine is not None:
+            self._active_routine.pause()
+        elif action == "resume" and self._active_routine is not None:
+            self._active_routine.resume()
 
     def _update_metadata(self, latest_message: dict[str, typing.Any]) -> None:
         """Handle a new imager command to update the configuration (i.e. the metadata)."""
@@ -351,6 +355,16 @@ class ImageAcquisitionRoutine(threading.Thread):
                     }
                 ),
             )
+
+    def pause(self) -> None:
+        """Pause the acquisition between steps."""
+        self._routine.pause()
+        self._mqtt_client.publish("status/imager", '{"status":"Paused"}')
+
+    def resume(self) -> None:
+        """Resume the acquisition after being paused."""
+        self._routine.resume()
+        self._mqtt_client.publish("status/imager", '{"status":"Resumed"}')
 
     def stop(self) -> None:
         """Stop the thread.

--- a/controller/imager/stopflow.py
+++ b/controller/imager/stopflow.py
@@ -99,6 +99,7 @@ class Routine:
 
         # Routine state
         self._interrupted = threading.Event()  # routine interrupted before completion
+        self._paused = threading.Event()  # routine paused between steps
         self._progress = 0  # the number of images acquired so far
         self._progress_lock = threading.Lock()
 
@@ -118,6 +119,12 @@ class Routine:
             return None
         with self._progress_lock:
             if self._progress >= self.settings.total_images:
+                return None
+
+        # Block while paused, checking for interruption every second
+        while self._paused.is_set():
+            if self._interrupted.wait(timeout=1.0):
+                loguru.logger.info("Image acquisition was interrupted while paused!")
                 return None
 
         self._pump.run_discrete(self.settings.pump)
@@ -150,6 +157,21 @@ class Routine:
             self._interrupted.set()
             self._pump.stop()
             loguru.logger.info("The image-acquisition routine has been interrupted!")
+
+    def pause(self) -> None:
+        """Pause the routine between steps."""
+        self._paused.set()
+        loguru.logger.info("The image-acquisition routine has been paused.")
+
+    def resume(self) -> None:
+        """Resume the routine after being paused."""
+        self._paused.clear()
+        loguru.logger.info("The image-acquisition routine has been resumed.")
+
+    @property
+    def paused(self) -> bool:
+        """Check whether the routine is currently paused."""
+        return self._paused.is_set()
 
     @property
     def interrupted(self) -> bool:


### PR DESCRIPTION
# Acquisition Pause/Resume Feature

**Branch (Python):** `Feature-Pause`
**Branch (Node-RED):** `Feature-Pause`
**Date:** 2026-03-30

---

## Summary

Adds the ability to pause and resume an active acquisition. Pause takes effect between frames, it will not interrupt a pump mid-flow or a capture mid-save, keeping the acquisition state clean and resumable without errors.

---

## Python Changes

### `controller/imager/stopflow.py` — Core pause logic

**New state:** Added `_paused` threading.Event to `Routine.__init__()`.

**Modified `run_step()`** — Added a blocking loop at the top of each step (after completion/interruption checks, before the pump runs):

```python
# Block while paused, checking for interruption every second
while self._paused.is_set():
    if self._interrupted.wait(timeout=1.0):
        loguru.logger.info("Image acquisition was interrupted while paused!")
        return None
```

This means:
- Pause only takes effect between frames (after the current frame completes)
- While paused, the routine checks for stop/interrupt every 1 second
- Stopping while paused works immediately (within 1s)

**New methods:**

```python
def pause(self) -> None:
    """Pause the routine between steps."""
    self._paused.set()

def resume(self) -> None:
    """Resume the routine after being paused."""
    self._paused.clear()
```

**New property:**

```python
@property
def paused(self) -> bool:
    """Check whether the routine is currently paused."""
    return self._paused.is_set()
```

### `controller/imager/main.py` — MQTT integration

**`Imager._handle_new_message()`** — Added two new action handlers:

```python
elif action == "pause" and self._active_routine is not None:
    self._active_routine.pause()
elif action == "resume" and self._active_routine is not None:
    self._active_routine.resume()
```

**`ImageAcquisitionRoutine`** — Added `pause()` and `resume()` methods that delegate to the routine and publish MQTT status:

```python
def pause(self) -> None:
    self._routine.pause()
    self._mqtt_client.publish("status/imager", '{"status":"Paused"}')

def resume(self) -> None:
    self._routine.resume()
    self._mqtt_client.publish("status/imager", '{"status":"Resumed"}')
```

---

## Node-RED Changes

All changes are in tracked in version conrtrol`flows.json` on the Acquisition tab (`71ede8b7dd88d90e`). A new branch was made to avoid confusion.

### UI Template (`body` node — `79bccc0355eb5d87`)

**New data property:**
- `acq_paused: false`

**Nice New button** (below Start/Stop, visible only during acquisition):
```html
<v-row v-if="acq_status === 'on'" class="align-center pa-0">
  <v-col cols="12" class="pa-0">
    <v-btn block :color="acq_paused ? 'green' : 'orange'" variant="outlined"
      class="mt-2" style="height: 48px" @click="handlePauseToggle">
      {{ acq_paused ? 'Resume Acquisition' : 'Pause Acquisition' }}
    </v-btn>
  </v-col>
</v-row>
```

**New method:**
```javascript
handlePauseToggle() {
  this.acq_paused = !this.acq_paused;
  if (typeof this.send !== "function") return;
  this.send({
    topic: "pause_control",
    payload: { action: this.acq_paused ? "pause" : "resume" }
  });
  this.acq_status_message = this.acq_paused ? "Paused" : "Resumed";
},
```

**Updated computed properties:**
- `formattedStatus`: "Paused" → "Acquisition paused. You may adjust settings.", "Resumed" → "Acquisition resumed."
- `statusColor`: "Paused" → orange, "Resumed" → green

**Updated status watcher:**
- Sets `acq_paused = true` on "paused" status, `false` on "resumed"
- Resets `acq_paused = false` when acquisition ends (done/stopped/error)

### New Flow Nodes

| Node | ID | Type | Purpose |
|------|----|------|---------|
| `pause?` | `a1b2c3d4e5f60001` | switch | Routes `pause_control` topic separately from normal acq messages |
| `pause/resume` | `a1b2c3d4e5f60002` | function | Sets `msg.topic = "imager/image"` for MQTT publish |

### Message Routing

```
body → pageleave filter → pageview filter → pause? switch
  ├─ topic="pause_control" → pause/resume func → MQTT out (imager/image)
  └─ else → acq_status switch → (stop / start paths, unchanged)
```

---

## MQTT API

### New Actions

| Topic | Payload | Effect |
|-------|---------|--------|
| `imager/image` | `{"action": "pause"}` | Pauses acquisition between frames |
| `imager/image` | `{"action": "resume"}` | Resumes paused acquisition |

### New Status Messages

| Topic | Payload | When |
|-------|---------|------|
| `status/imager` | `{"status": "Paused"}` | After pause takes effect |
| `status/imager` | `{"status": "Resumed"}` | After resume |

---

## Behavior

- The nice new Pause button appears only when acquisition is running (`acq_status === 'on'`)
- Button toggles between orange "Pause Acquisition" and green "Resume Acquisition"
- Pause takes effect after the current frame completes (pump + stabilize + capture)
- Stopping while paused works — the interrupt check runs every 1 second
- When acquisition ends (done/stopped/error), pause state resets automatically
- No changes to existing start/stop flow, MQTT topics, or pump/camera control so nothing should break
