### PR TITLE
lib: Fix gateway connectivity checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,8 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+indent_style = space
+indent_size = 2
 
 [*.py]
 indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ node_modules
 # PlanktoScope config files
 hardware.json
 config.json
-
-push.sh
+calibration.json
 
 data

--- a/lib/network/network.js
+++ b/lib/network/network.js
@@ -1,5 +1,3 @@
-import "observable-polyfill"
-
 import { wired_controller } from "./wired.js"
 
 export { wired_controller }

--- a/lib/network/util.js
+++ b/lib/network/util.js
@@ -1,0 +1,10 @@
+import { execa } from "execa"
+
+export async function pingWired(interf, host) {
+  try {
+    await execa("ping", ["-c", "1", "-I", interf, host])
+    return true
+  } catch {
+    return false
+  }
+}

--- a/lib/network/wired.js
+++ b/lib/network/wired.js
@@ -1,7 +1,8 @@
 /* eslint-disable n/no-top-level-await */
 
+import "observable-polyfill"
 import { systemBus } from "dbus.js"
-import { execa } from "execa"
+import { $ } from "execa"
 import { queue } from "../helpers.js"
 import { readProperty, watchProperty } from "../dbus-helpers.js"
 
@@ -45,10 +46,14 @@ async function getWiredConnectivity() {
   return { address, gateway }
 }
 
-async function pingWired(host) {
+// Check that a computer on the same network is reachable using ARP
+async function isNeighborReachable(ip, dev = wired_interface) {
   try {
-    await execa("ping", ["-c", "1", "-I", wired_interface, host])
-    return true
+    const { stdout } = await $`ip --json neighbour get to ${ip} dev ${dev}`
+    // ip neighbour get returns a single entry
+    const { lladdr, state } = JSON.parse(stdout)[0]
+    // Check that we have the mac address of the neighbour
+    return Boolean(lladdr && !state.includes("FAILED"))
   } catch {
     return false
   }
@@ -66,7 +71,7 @@ export const wired_controller = new Observable(async (subscriber) => {
 
   async function testGateway({ gateway, address }) {
     try {
-      nextValue((await pingWired(gateway)) ? address : null)
+      nextValue((await isNeighborReachable(gateway)) ? address : null)
     } catch (err) {
       console.error(err)
     }


### PR DESCRIPTION
Internet gateway can block ICMP / ping (Windows in particular) so let's use ARP instead to detect connectivity.

This was uncovered with @tcebron the setup was his Windows laptop +ICS <- Ethernet <-> PlanktoScope 