### PR TITLE
segmenter: emit object_contour polygon for audit visualizer

### DIFF
--- a/segmenter/planktoscope/segmenter/__init__.py
+++ b/segmenter/planktoscope/segmenter/__init__.py
@@ -504,6 +504,21 @@ class SegmenterProcess(multiprocessing.Process):
             if threshold_value is not None:
                 metadata["threshold"] = threshold_value
 
+            # External contour polygon in full-frame pixel coords, for the audit
+            # visualizer. Compact JSON list of [x, y] points; consumers can parse
+            # it with JSON.parse.
+            obj_contours, _ = cv2.findContours(
+                np.uint8(region.filled_image),
+                mode=cv2.RETR_EXTERNAL,
+                method=cv2.CHAIN_APPROX_SIMPLE,
+            )
+            if obj_contours:
+                min_row, min_col = region.bbox[0], region.bbox[1]
+                poly = obj_contours[0].reshape(-1, 2)
+                metadata["contour"] = json.dumps(
+                    [[int(p[0] + min_col), int(p[1] + min_row)] for p in poly]
+                )
+
             # Second extract to get a bigger image for saving
             obj_image = img[__augment_slice(region.slice, labels.shape, 10)]
             object_id = f"{name}_{i}"


### PR DESCRIPTION
Adds an `object_contour` column to the EcoTaxa TSV containing each object's external contour as a JSON-encoded list of [x, y] points in full-frame pixel coordinates. The audit page's "contours" view (already in `feature/audit-page-port` of the dashboard subrepo) consumes this column to draw real object outlines; without it, the view falls back to tiny bbox silhouettes. Polygon is extracted from `region.filled_image` via `cv2.findContours(RETR_EXTERNAL, CHAIN_APPROX_SIMPLE)` and offset into frame coords by the bbox origin.