### PR TITLE
imager: Reduce luminance difference between preview and capture streams

### DIFF
--- a/.github/workflows/build-controller.yml
+++ b/.github/workflows/build-controller.yml
@@ -46,7 +46,7 @@ jobs:
         run: uv python install
 
       - name: Install build dependencies
-        run: sudo apt install -y libcap-dev
+        run: sudo apt-get update && sudo apt install -y libcap-dev
 
       - name: Install dependencies
         working-directory: ./controller

--- a/.github/workflows/build-controller.yml
+++ b/.github/workflows/build-controller.yml
@@ -46,11 +46,7 @@ jobs:
         run: uv python install
 
       - name: Install build dependencies
-<<<<<<< fix/preview-luminance-range
-        run: sudo apt-get update && sudo apt install -y libcap-dev
-=======
         run: sudo apt-get update && sudo apt-get install -y libcap-dev
->>>>>>> main
 
       - name: Install dependencies
         working-directory: ./controller

--- a/controller/imager/camera/hardware.py
+++ b/controller/imager/camera/hardware.py
@@ -3,6 +3,7 @@
 import os
 import typing
 
+import libcamera  # type: ignore
 import loguru
 import picamera2  # type: ignore
 from picamera2 import encoders, outputs
@@ -278,11 +279,17 @@ class PiCamera:
             lores_config["size"] = lores_size
         # Note(ethanjli): we use the `create_still_configuration` to get the best defaults for still
         # images from the "main" stream:
+        # Request BT.601 limited-range YUV (Smpte170m) for the lores stream so that the H.264
+        # encoder's default color_range tag (limited) matches the pixel data. Without this, the
+        # ISP delivers full-range sYCC YUV but the H.264 VUI advertises limited range, causing
+        # browser/RTSP decoders to re-expand the values and display the preview ~5% brighter than
+        # the saved JPEG. See docs/preview_luminance_fix/README.md.
         config = self._camera.create_still_configuration(
             main_config,
             lores_config,
             buffer_count=self._stream_config.buffer_count,
             queue=self._stream_config.queue,
+            colour_space=libcamera.ColorSpace.Smpte170m(),
         )
         loguru.logger.debug(f"Camera configuration: {config}")
         self._camera.configure(config)

--- a/controller/imager/camera/hardware.py
+++ b/controller/imager/camera/hardware.py
@@ -279,16 +279,16 @@ class PiCamera:
             lores_config["size"] = lores_size
         # Note(ethanjli): we use the `create_still_configuration` to get the best defaults for still
         # images from the "main" stream:
-        # Request BT.601 limited-range YUV (Smpte170m) for the lores stream so that the H.264
-        # encoder's default color_range tag (limited) matches the pixel data. Without this, the
-        # ISP delivers full-range sYCC YUV but the H.264 VUI advertises limited range, causing
-        # browser/RTSP decoders to re-expand the values and display the preview ~5% brighter than
-        # the saved JPEG. See docs/preview_luminance_fix/README.md.
         config = self._camera.create_still_configuration(
             main_config,
             lores_config,
             buffer_count=self._stream_config.buffer_count,
             queue=self._stream_config.queue,
+            # Request BT.601 limited-range YUV (Smpte170m) for the lores stream so that the H.264
+            # encoder's default color_range tag (limited) matches the pixel data. Without this, the
+            # ISP delivers full-range sYCC YUV but the H.264 VUI advertises limited range, causing
+            # browser/RTSP decoders to re-expand the values and display the preview ~5% brighter than
+            # the saved JPEG. See https://github.com/fairscope/PlanktoScope/pull/941
             colour_space=libcamera.ColorSpace.Smpte170m(),
         )
         loguru.logger.debug(f"Camera configuration: {config}")


### PR DESCRIPTION
# Preview vs. acquired image luminance mismatch

## The symptom

Looking at the PlanktoScope dashboard, the live preview stream is looks a bit brighter
(and with a bit lower contrast) than the JPEG images the thing actually saves.

Measured mean luminance (BT.601 Y, 0–255) on an empty flowcell under fixed LED:

| Stage                        | Mean Y  |
|------------------------------|--------:|
| Saved JPEG (what you archive)| 184.9   |
| Live preview (what you see)  | 195.1   |
| Difference                   | **+10 Y (~5%)** |

That's 5% , so it does look obviously brighter
and kind of grayer than the captured image.

### Before the fix — same scene, same instant, two different pictures


<img width="1830" height="770" alt="comparison_before" src="https://github.com/user-attachments/assets/6e83ab23-e963-4f04-9237-155915dab7d9" />


## Why it happens

The camera has two output streams coming out of the same sensor at the same time:

- **Capture stream (`main`)** — 4056×3040, RGB. Saved directly as a JPEG.
- **Preview stream (`lores`)** — 1920×1440, YUV420. Fed into an H.264 encoder
  and streamed over RTSP to the browser.

The camera's processor hands the preview stream out as YUV data
that uses **the full 0–255 range** for every pixel — bright whites reach 255,
dark blacks reach 0.

H.264 video, however, is weird. Every H.264 stream carries
a little flag in its header telling the decoder which range to expect.
The PlanktoScope's preview stream was **not setting that flag**, so the browser
assumed it was a traditional limited-range stream, because evidently it was for TV.

So here is what was happening end-to-end:

1. ISP produces preview YUV in **full range** (Y=185 for a bright nice empty flowcell).
2. H.264 encoder wraps that up and — because the flag was never set — tags it
   as **limited range**.
3. Browser receives the stream, reads the "limited range" tag, and does the
   standard stretch: `Y* = (Y − 16) × 255/219`. So it turns Y=185 into Y*≈197,
   lightening the whole image by about 5%.
4. The saved JPEG goes through a completely different path (no H.264, no
   range conversion) and shows up on disk at its true Y=185.

The preview path was lying about what
kind of data it contained, and the browser was dutifully "fixing" it.

## The fix

One line, in `controller/imager/camera/hardware.py`, where the camera streams
are configured:

```python
config = self._camera.create_still_configuration(
    main_config,
    lores_config,
    buffer_count=self._stream_config.buffer_count,
    queue=self._stream_config.queue,
    colour_space=libcamera.ColorSpace.Smpte170m(),   # <-- added
)
```

`ColorSpace.Smpte170m()` tells the camera stream to produce the preview YUV in
limited range to begin with. Now the data (limited range) and the H.264 tag
(limited range) agree, and the browser's standard stretch is the correct
operation.

Effect on the capture path: **none**. The `main` stream is RGB, not YUV;
`colour_space` only affects the YUV preview.

Effect on preview quality: we give up 16 code values at each end of the preview
luminance range (0–15 and 236–255, which were mostly unused anyway). 223 levels
is still far beyond what a human can distinguish on the dashboard.

### After the fix — preview and capture now match

<img width="1830" height="770" alt="comparison_after" src="https://github.com/user-attachments/assets/d75a0406-d125-4557-b2ad-7e436e2c2d9f" />


| Stage                        | Before  | After   |
|------------------------------|--------:|--------:|
| Saved JPEG (mean Y)          | 184.9   | 184.8   |
| Live preview (mean Y)        | 195.1   | 183.2   |
| **Preview − capture**        | **+10.2** | **−1.6** |

