### PR TITLE
controller: add Planktoscope unit number to metadata

### DIFF
--- a/controller/imager/main.py
+++ b/controller/imager/main.py
@@ -1,5 +1,6 @@
 """mqtt provides an MQTT worker to perform stop-flow image acquisition."""
 
+import base64
 import datetime
 import json
 import os
@@ -16,6 +17,26 @@ from imager.camera.hardware import ISO_CALIBRATION
 
 from . import stopflow
 from .camera import mqtt as camera
+
+HAT_CUSTOM_DATA_PATH = "/proc/device-tree/hat/custom_0"
+
+
+def _read_hat_serial_number() -> typing.Optional[str]:
+    """Read the FairScope HAT serial number from the HAT EEPROM.
+
+    The Raspberry Pi exposes HAT EEPROM custom data under /proc/device-tree/hat as a NUL-terminated
+    blob. FairScope HATs store a base64-encoded JSON object containing the serial_number key.
+    """
+    try:
+        with open(HAT_CUSTOM_DATA_PATH, "rb") as f:
+            blob = f.read().rstrip(b"\x00").strip()
+        if not blob:
+            return None
+        decoded = base64.b64decode(blob, validate=True)
+        serial = json.loads(decoded).get("serial_number")
+        return str(serial) if serial else None
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
 
 
 class Imager:
@@ -176,6 +197,8 @@ class Imager:
             "acq_uuid": str(uuid4()),
             "sample_uuid": str(uuid4()),
         }
+        if (serial_number := _read_hat_serial_number()) is not None:
+            metadata["acq_instrument_serial_number"] = serial_number
         # Resolve pixel size (µm/px) for the segmenter's unit conversion.
         # Node-RED resolves the correct value from the per-preset calibration
         # matrix and sends it as process_pixel.


### PR DESCRIPTION
  ## Summary                                                                                                                            
   
  Adds the FairScope HAT serial number (e.g. `U383`) to every acquisition's metadata so the produced data can be traced back to the     
  specific physical instrument that produced it.
                                                                                                                                        
  The serial number is already stored in the HAT EEPROM (read from `/proc/device-tree/hat/custom_0`, base64-decoded JSON) and previously
   surfaced only in the JS layer via `lib/hardware.js`. Until now, EcoTaxa exports identified the instrument only by software model
  (`acq_instrument`) and machine name (`acq_instrument_id`), so two different physical units sharing the same machine name (or a unit   
  later renamed) couldn't be distinguished in the archive.

  ## What changed

  - `controller/imager/main.py`
    - New `_read_hat_serial_number()` helper — reads `/proc/device-tree/hat/custom_0`, strips the trailing NUL, base64-decodes,
  JSON-parses, returns the `serial_number` value, or `None` on any failure.                                                             
    - In `_start_acquisition`, when the read succeeds, set `metadata["acq_instrument_serial_number"] = serial`. **The key is omitted 
  entirely on read failure** so non-FairScope HATs do not get a misleading column.                                                      
                  
  No segmenter changes are needed — the existing `acq_*` prefix filter in `segmenter/planktoscope/segmenter/__init__.py` already        
  forwards every `acq_` key from `metadata.json` straight to the EcoTaxa TSV.
                                                                                                                                        
  ## Why this injection point                                                                                                           
   
  Reading at acquisition start (rather than at segmentation time) binds the serial to the data at capture, not at processing. If someone
   later segments on a different machine or swaps HATs between capture and segmentation, the serial in the TSV still reflects the
  instrument that produced the images. The value also lands in `metadata.json` next to the images, so it travels with the acquisition   
  folder regardless of EcoTaxa export.

  ## Field naming

  - Column name: `acq_instrument_serial_number`
  - Follows EcoTaxa's `acq_*` prefix convention for instrument-related metadata
  - Distinct from the existing `acq_instrument_id` (which is the human-friendly machine name like `sponge-care-xxx`)
  - EcoTaxa type marker resolves to `[t]` (text) automatically                                                                          
                                                                                                                                        
  ## Test plan                                                                                                                          
                                                                                                                                        
  - [x] Helper returns the serial on a v3.0 HAT (`U383`) and `None` for missing/garbage/empty EEPROM blobs                              
  - [x] Imager service restarts cleanly with the change deployed
  - [x] Real acquisition writes `"acq_instrument_serial_number": "U383"` into `metadata.json`                                           
  - [x] Segmenter output (`ecotaxa_testerunit_1_A_1.zip`) contains the column in the TSV header (col 47), type marker `[t]`, value      
  `U383` consistent across all 68 object rows                                                                                           
  - [x] No regression — all 35 existing `acq_*` / `sample_*` columns still populate correctly (`acq_uuid`, `sample_uuid`, `acq_id`,     
  etc.)                                                                                                                                 
  - [ ] Confirm behavior on a non-FairScope HAT or unit with no `custom_0` (should silently omit the column — verified via local helper,
   not on hardware) 