### PR TITLE
ci: apt-get update before installing libcap-dev

### DIFF
--- a/.github/workflows/build-controller.yml
+++ b/.github/workflows/build-controller.yml
@@ -46,7 +46,7 @@ jobs:
         run: uv python install
 
       - name: Install build dependencies
-        run: sudo apt install -y libcap-dev
+        run: sudo apt-get update && sudo apt-get install -y libcap-dev
 
       - name: Install dependencies
         working-directory: ./controller


### PR DESCRIPTION
## Summary

`build-controller.yml` runs `sudo apt install -y libcap-dev` without first refreshing the apt index. When Ubuntu rotates a security update for `libcap2`/`libcap-dev` (as happened with `2.66-5ubuntu2.2`), the runner's cached index points to a `.deb` that's no longer on the mirror and the install fails with `404 Not Found` → `exit code 100`.

Hit on PR #942 (run 24971308570) twice in a row.

## Change

Prepend `sudo apt-get update` to the install step so the runner pulls the current package version every time.

## Test plan

- [ ] CI passes on this PR
- [ ] Re-trigger CI on PR #942 once this lands; the libcap-dev step succeeds