### PR TITLE
segmenter: standardize EcoTaxa naming conventions

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -190,7 +190,7 @@ async function getSegmentationFromPath(path) {
       continue
     }
 
-    if (extension === ".tsv" && (file.startsWith("Ecotaxa_") || file.startsWith("ecotaxa_"))) {
+    if (extension === ".tsv" && file.toLowerCase().startsWith("ecotaxa_")) {
       tsv_path = join(path, file)
     }
   }
@@ -200,9 +200,9 @@ async function getSegmentationFromPath(path) {
   if (!tsv_row) return null
 
   const project_name = tsv_row.sample_project
+  // https://github.com/fairscope/PlanktoScope/pull/946
   const sample_id =
-    tsv_row.sample_id.split(tsv_row.sample_project + "_")[1] ||
-    tsv_row.sample_id
+    tsv_row.sample_id.split(sample_id + "_")[1] || tsv_row.sample_id
   const acquisition_id =
     tsv_row.acq_id.split(sample_id + "_")[1] || tsv_row.acq_id
 

--- a/segmenter/planktoscope/segmenter/__init__.py
+++ b/segmenter/planktoscope/segmenter/__init__.py
@@ -870,7 +870,7 @@ class SegmenterProcess(multiprocessing.Process):
         self.__archive_fn = os.path.join(
             self.__ecotaxa_path,
             # TODO #102 sanitize the filename to remove potential problems with spaces and special characters
-            f"Ecotaxa_{project}_{acquisition}.zip",
+            f"Ecotaxa_{sample}_{acquisition}.zip",
         )
 
         self.__working_path = path

--- a/segmenter/planktoscope/segmenter/ecotaxa.py
+++ b/segmenter/planktoscope/segmenter/ecotaxa.py
@@ -237,6 +237,13 @@ def ecotaxa_export(archive_filepath, metadata, image_base_path, keep_files=False
             logger.error("No objects metadata recorded, cannot continue the export")
             return 0
 
+        # Concatenated sample+acq id for both TSV columns and the filename.
+        sample_id = metadata.get("sample_id", "unknown_sample").replace(" ", "_")
+        acquisition_id = metadata.get("acq_id", "unknown_acq").replace(" ", "_")
+        combined_id = f"{sample_id}_{acquisition_id}"
+        metadata["sample_id"] = combined_id
+        metadata["acq_id"] = combined_id
+
         # sometimes the camera resolution is not exported as string
         if not isinstance(metadata["acq_camera_resolution"], str):
             metadata["acq_camera_resolution"] = (
@@ -269,10 +276,7 @@ def ecotaxa_export(archive_filepath, metadata, image_base_path, keep_files=False
             list(zip(tsv_content.columns, tsv_type_header))
         )
 
-        # create the filename with project name and acquisition ID
-        project = metadata.get("sample_project", "unknown_project").replace(" ", "_")
-        acquisition_id = metadata.get("acq_id", "unknown_acq").replace(" ", "_")
-        tsv_filename = f"Ecotaxa_{project}_{acquisition_id}.tsv"
+        tsv_filename = f"Ecotaxa_{sample_id}_{acquisition_id}.tsv"
 
         # add the tsv to the archive
         archive.writestr(


### PR DESCRIPTION
Fixes https://github.com/fairscope/PlanktoScope3/issues/270

Updates naming in the segmenter to align with EcoTaxa requirements and improve metadata consistency.