### PR TITLE
lib: add operator_name to listSegmentations payload

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -210,6 +210,7 @@ async function getSegmentationFromPath(path) {
     project_name,
     sample_id,
     acquisition_id,
+    operator_name: tsv_row.sample_operator,
     image_acquired_count,
     path,
     gallery: getGalleryPath(path),


### PR DESCRIPTION
Adds `operator_name` (read from `sample_operator` in the segmentation TSV's first row) to `getSegmentationFromPath()` in `lib/db.js`. Enables sorting the Visualization page's List of Segmentation by operator, parity with the Segmentation page's List of Acquisitions.