### PR TITLE
os/image: Use stable GPT PARTUUIDs

### DIFF
--- a/os/image/package-lock.json
+++ b/os/image/package-lock.json
@@ -8,6 +8,7 @@
         "dedent": "^1.7.2",
         "execa": "^9.6.1",
         "ini": "^6.0.0",
+        "uuid": "^14.0.0",
         "write-file-atomic": "^7.0.1"
       },
       "devDependencies": {
@@ -1298,6 +1299,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/os/image/package.json
+++ b/os/image/package.json
@@ -5,6 +5,7 @@
     "dedent": "^1.7.2",
     "execa": "^9.6.1",
     "ini": "^6.0.0",
+    "uuid": "^14.0.0",
     "write-file-atomic": "^7.0.1"
   },
   "devDependencies": {

--- a/os/image/planktoscope.js
+++ b/os/image/planktoscope.js
@@ -10,6 +10,7 @@ import {
 } from "node:fs/promises"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { v5 as uuidv5 } from "uuid"
 
 import { $ } from "execa"
 import { stringify, parse } from "ini"
@@ -18,6 +19,12 @@ import dedent from "dedent"
 import { getBlockDevices, getMountPoint } from "./lib.js"
 
 const bootnames = ["A", "B"]
+
+// Fixed namespace UUID
+const NAMESPACE = "11311d13-358c-4d63-8e9a-fd2ca83e08ea"
+function stablePartUuid(name) {
+  return uuidv5(name, NAMESPACE)
+}
 
 export async function createPartitions(device, rpios_partitions) {
   // We create the entire partition table first
@@ -71,23 +78,23 @@ async function createPartitionTable(device) {
 
   // BOOTLOADER
   partn++
-  await $`sgdisk --new=${partn}:0:+8M --typecode=${partn}:0700 -A ${partn}:set:0 -A ${partn}:set:1 -A ${partn}:set:62 -A ${partn}:set:63 --change-name=${partn}:BOOTLOADER ${device}`
+  await $`sgdisk --new=${partn}:0:+8M --typecode=${partn}:0700 -A ${partn}:set:0 -A ${partn}:set:1 -A ${partn}:set:62 -A ${partn}:set:63 --change-name=${partn}:BOOTLOADER --partition-guid=${partn}:${stablePartUuid("BOOTLOADER")} ${device}`
 
   // FIRMWARE X
   for (const bootname of bootnames) {
     partn++
-    await $`sgdisk --new=${partn}:0:+256M --typecode=${partn}:0700 -A ${partn}:set:0 -A ${partn}:set:1 -A ${partn}:set:62 -A ${partn}:set:63 --change-name=${partn}:${"FIRMWARE_" + bootname} ${device}`
+    await $`sgdisk --new=${partn}:0:+256M --typecode=${partn}:0700 -A ${partn}:set:0 -A ${partn}:set:1 -A ${partn}:set:62 -A ${partn}:set:63 --change-name=${partn}:${"FIRMWARE_" + bootname} --partition-guid=${partn}:${stablePartUuid("FIRMWARE_" + bootname)} ${device}`
   }
 
   // ROOT X
   for (const bootname of bootnames) {
     partn++
-    await $`sgdisk --new=${partn}:0:+10G --typecode=${partn}:8300 -A ${partn}:set:0 -A ${partn}:set:1 -A ${partn}:set:62 -A ${partn}:set:63 --change-name=${partn}:${"ROOT_" + bootname} ${device}`
+    await $`sgdisk --new=${partn}:0:+10G --typecode=${partn}:8300 -A ${partn}:set:0 -A ${partn}:set:1 -A ${partn}:set:62 -A ${partn}:set:63 --change-name=${partn}:${"ROOT_" + bootname} --partition-guid=${partn}:${stablePartUuid("ROOT_" + bootname)} ${device}`
   }
 
   // "DATA"
   partn++
-  await $`sgdisk --new=${partn}:0:0 --typecode=${partn}:8300 -A ${partn}:set:0 -A ${partn}:set:1  -A ${partn}:set:62 -A ${partn}:set:63 --change-name=${partn}:DATA ${device}`
+  await $`sgdisk --new=${partn}:0:0 --typecode=${partn}:8300 -A ${partn}:set:0 -A ${partn}:set:1  -A ${partn}:set:62 -A ${partn}:set:63 --change-name=${partn}:DATA --partition-guid=${partn}:${stablePartUuid("DATA")} ${device}`
 
   await $`sgdisk --verify ${device}`
 


### PR DESCRIPTION
Fixes https://github.com/fairscope/PlanktoScope3/issues/538

Unfortunately there isn't really a way to make this work in a way that we can reliably boot the same image both from nvme and sdcard.

For v2.6 it's fine, sdcard only.
For v3.0 the system is officially running from nvme but we may need/want to run from sdcard? If so we'll need to generate a separate "sdcard" image with different PARTUUID.

The good thing is that we can mount the image as a loopback device and change the PARTUUID on the fly without regenerating the whole image.

But it also means we'll need separate rauc bundles for updates. Perhaps for simplicity we shouldn't support booting PlanktoScope OS from sdcard. Specially since we have a/b - it's always possible to test an image / bundle on a slot.