### PR TITLE
os/image: Do not create multiple cmdline files

### DIFF
--- a/os/image/README.md
+++ b/os/image/README.md
@@ -86,7 +86,7 @@ sudo mount -o remound,ro /bootloader
 
 ---
 
-`FIRMWARE_A` and `FIRMWARE_B` are equivalent to RPI OS `bootfs`. `cmdline.txt` is replaced with `cmdline-A.txt` and `cmdline-B.txt`. `config.txt` is updated to choose the appropriate cmdline file based on the boot partition.
+`FIRMWARE_A` and `FIRMWARE_B` are equivalent to RPI OS `bootfs`.
 
 `/etc/fstab` must be the sames on both `A` and `B` so we cannot use it to mount `/boot/firmware`, instead it is mounted by the `mount-firmware` service.
 
@@ -125,10 +125,9 @@ Here is a simplified "high level" sequence of what happens:
 0. Raspberry Pi powers on
 1. EEPROM bootloader opens the first partition `BOOTLOADER` and reads `autoboot.txt`
 2. Firmware (GPU) initializes with the partition `FIRMWARE_A|B` defined in `autoboot.txt` (boot or tryboot depending on the state flag)
-3. The firmware opens the partition and reads `config.txt` which tells it which `cmdline-A|B.txt` file to use
-4. It initializes the Linux kernel using the cmdline arguments and mounts the given `ROOT_A|B` partition
-5. systemd reads `/etc/fstab` and mounts accordingly
+3. It initializes the Linux kernel using the cmdline arguments which mounts the specified `ROOT_A|B` partition
+4. systemd reads `/etc/fstab` and mounts accordingly
    - `BOOTLOADER` to `/bootloader` - readonly
    - `DATA` to `/data` - readwrite
    - `DATA/home` to `/home`
-6. systemd executes `mount-firmware.service` and `/boot/firmware` becomes available
+5. systemd executes `mount-firmware.service` and `/boot/firmware` becomes available

--- a/os/image/planktoscope.js
+++ b/os/image/planktoscope.js
@@ -53,7 +53,6 @@ export async function updateMountpoints(device, rpios_partitions) {
   const partitions = await getPartitions(device)
 
   await setup_cmdline(rpios_partitions, partitions)
-  await setup_config(rpios_partitions, partitions)
   await setup_cloudinit(rpios_partitions, partitions)
   await setup_fstab(partitions)
   await setup_autoboot(partitions)
@@ -270,31 +269,6 @@ async function setup_cloudinit(rpios_partitions, partitions) {
   }
 }
 
-async function setup_config(rpios_partitions, partitions) {
-  const content = await readFile(
-    join(rpios_partitions["bootfs"].mountpoint, "config.txt"),
-    "utf8",
-  )
-
-  let config = "[all]\n\n"
-  for (const bootname of bootnames) {
-    const part = partitions[`FIRMWARE_${bootname}`]
-    config += dedent`
-      [boot_partition=${part.partn}]
-      cmdline=cmdline-${bootname}.txt
-    `
-    config += "\n"
-  }
-
-  config += "\n[all]\n\n" + content
-
-  for (const bootname of bootnames) {
-    const part = partitions[`FIRMWARE_${bootname}`]
-    const path = join(part.mountpoint, "config.txt")
-    await writeFile(path, config)
-  }
-}
-
 async function setup_cmdline(rpios_partitions, partitions) {
   const rpios_bootfs = rpios_partitions["bootfs"]
   const rpios_rootfs = rpios_partitions["rootfs"]
@@ -320,24 +294,12 @@ async function setup_cmdline(rpios_partitions, partitions) {
   // since we don't have / in /etc/fstab we need to specify rw
   args.push("rw")
 
-  // generate a cmdline for each bootname
-  const cmdlines = []
   for (const bootname of bootnames) {
     const rootfs = partitions[`ROOT_${bootname}`]
     const clone = structuredClone(args)
     clone[root_idx] = `root=PARTUUID=${rootfs.partuuid}`
-    cmdlines.push([`cmdline-${bootname}.txt`, clone.join(" ")])
-  }
-
-  // write all cmdline files to all firmware partitions
-  // see config.txt
-  for (const bootname of bootnames) {
     const firmware_mp = partitions[`FIRMWARE_${bootname}`].mountpoint
-    for (const [file, content] of cmdlines) {
-      await writeFile(join(firmware_mp, file), content)
-    }
-    // remove original cmdline.txt
-    await unlink(join(firmware_mp, "cmdline.txt"))
+    await writeFile(join(firmware_mp, "cmdline.txt"), clone.join(" "))
   }
 }
 


### PR DESCRIPTION
While working on automating updates I realized were were doing something unnecessary for our A/B setup.

We were creating 2 cmdline files per slot. Because each slot has a separate firmware/boot partition it is not necessary.

See https://www.raspberrypi.com/documentation/computers/config_txt.html#boot_partition-2

> This is intended for use with an A/B boot-system with autoboot.txt where it is desirable to be able to have identical files installed to the boot partition for both the A and B images.

(It is not our case).

This simplifies the boot process.