### PR TITLE
caddy: alias /dashboard to the real Node-RED dashboard path

### DIFF
--- a/os/caddy/Caddyfile
+++ b/os/caddy/Caddyfile
@@ -76,8 +76,9 @@
 	# FlowFuse Dashboard 2 reload-after-disconnect bug: when the WebSocket
 	# drops (laptop sleep, planktoscope reboot, etc.) the bundled JS calls
 	# new URL(window.location.origin + "/dashboard") to refresh, ignoring
-	# the actual httpAdminRoot. Without this alias the reload URL becomes
+	# the actual httpNodeRoot. Without this alias the reload URL becomes
 	# /dashboard?reloadTime=... and falls through to the SPA 404 page.
+  # see https://github.com/FlowFuse/node-red-dashboard/issues/2149
 	redir /dashboard /ps/node-red-v2/dashboard/ 302
 	redir /dashboard/ /ps/node-red-v2/dashboard/ 302
 

--- a/os/caddy/Caddyfile
+++ b/os/caddy/Caddyfile
@@ -72,6 +72,15 @@
 		}
 	}
 
+	# alias /dashboard -> real Node-RED dashboard path
+	# FlowFuse Dashboard 2 reload-after-disconnect bug: when the WebSocket
+	# drops (laptop sleep, planktoscope reboot, etc.) the bundled JS calls
+	# new URL(window.location.origin + "/dashboard") to refresh, ignoring
+	# the actual httpAdminRoot. Without this alias the reload URL becomes
+	# /dashboard?reloadTime=... and falls through to the SPA 404 page.
+	redir /dashboard /ps/node-red-v2/dashboard/ 302
+	redir /dashboard/ /ps/node-red-v2/dashboard/ 302
+
 	# Frontend fallback (everything else)
 	handle {
 		root * /opt/PlanktoScope/frontend/dist


### PR DESCRIPTION
  ## Summary

  Fix the "404: It's gone 😞" page that users see when reopening a tab that had the dashboard loaded before the laptop was
  put to sleep (or the PlanktoScope was rebooted).

  ## Root cause

  \`@flowfuse/node-red-dashboard@1.30.2\` hardcodes the reload URL in its bundled JS
  (\`node_modules/@flowfuse/node-red-dashboard/dist/assets/index-B1862Wtn.js\`):

  \`\`\`js
  new URL(window.location.origin + "/dashboard")
  url.searchParams.set("reloadTime", Date.now().toString() + Math.random());
  \`\`\`

  It ignores Node-RED's \`httpAdminRoot\`. On PlanktoScope the dashboard is mounted at \`/ps/node-red-v2/dashboard/\`, so
  the reload navigates the browser to \`/dashboard?reloadTime=...\` which doesn't exist — it falls through to the SPA, and
  the SolidJS router renders its 404 component.

  ## Fix

  Add a Caddy \`redir\` block above the frontend fallback that aliases \`/dashboard\` (and \`/dashboard/\`) to the real
  Node-RED path. The redirect target drops the query string, so \`reloadTime\` disappears in the bounce.

  ## Test plan

  - [x] \`curl -sL -o /dev/null -w '%{http_code} %{url_effective}\n' 'http://<pi>/dashboard?reloadTime=17750671652900'\`
  ends at \`200 http://<pi>/ps/node-red-v2/dashboard/\`
  - [x] Reproduced the original scenario (dashboard open → laptop sleep → wake → tab loads correctly)
  - [x] \`caddy validate\` passes
  - [x] \`/ps/node-red-v2/dashboard/\` direct access still 200 (no regression)

  ## Upstream

  Worth filing at https://github.com/FlowFuse/node-red-dashboard so other projects with non-root \`httpAdminRoot\` don't hit
   this. This PR is a workaround; safe to remove once FlowFuse takes the URL from the browser's current location instead of
  hardcoding \`/dashboard\`.
