### PR TITLE
mediamtx: substitute hostname/IP before start

### DIFF
--- a/os/mediamtx/justfile
+++ b/os/mediamtx/justfile
@@ -8,7 +8,6 @@ setup:
     sudo cp mediamtx.service /etc/systemd/system/
     sudo cp mediamtx.yaml /etc/mediamtx.yaml
     sudo chown pi:pi /etc/mediamtx.yaml
-    sudo node ../../lib/mediamtx.js
     sudo systemctl reenable mediamtx
     sudo systemctl restart mediamtx
 

--- a/os/mediamtx/mediamtx.service
+++ b/os/mediamtx/mediamtx.service
@@ -1,10 +1,16 @@
 # https://mediamtx.org/docs/usage/start-on-boot#linux
 
 [Unit]
-After=network.target
-Wants=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
+# Rewrite /etc/mediamtx.yaml with this device's real hostname and IP before
+# mediamtx loads it, replacing the placeholders shipped in the YAML template.
+# Without this, WebRTC ICE candidates advertise "raspberrypi" which browsers
+# cannot resolve, causing silent peer-connection failures (dashboard preview
+# spins forever).
+ExecStartPre=/usr/bin/node /opt/PlanktoScope/lib/mediamtx.js
 ExecStart=/usr/local/bin/mediamtx /etc/mediamtx.yaml
 
 [Install]

--- a/os/mediamtx/mediamtx.service
+++ b/os/mediamtx/mediamtx.service
@@ -5,12 +5,10 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-# Rewrite /etc/mediamtx.yaml with this device's real hostname and IP before
-# mediamtx loads it, replacing the placeholders shipped in the YAML template.
-# Without this, WebRTC ICE candidates advertise "raspberrypi" which browsers
-# cannot resolve, causing silent peer-connection failures (dashboard preview
-# spins forever).
-ExecStartPre=/usr/bin/node /opt/PlanktoScope/lib/mediamtx.js
+# The hostname/IP substitution into /etc/mediamtx.yaml is driven by the
+# `runOnInit` hook in the YAML itself (see os/mediamtx/mediamtx.yaml), so it
+# also runs when mediamtx is started outside systemd (e.g. `just dev`).
+# network-online.target is kept so the wired IP is available when that runs.
 ExecStart=/usr/local/bin/mediamtx /etc/mediamtx.yaml
 
 [Install]

--- a/os/mediamtx/mediamtx.yaml
+++ b/os/mediamtx/mediamtx.yaml
@@ -37,3 +37,8 @@ paths:
     alwaysAvailable: true
     alwaysAvailableTracks:
       - codec: H264
+    # Rewrite this file's placeholder hostname/IP (above) with the device's real
+    # values at startup, so WebRTC ICE candidates resolve regardless of how
+    # mediamtx was launched (systemd, `just dev`, manual). mediamtx watches the
+    # config file and hot-reloads after the rewrite. See lib/mediamtx.js.
+    runOnInit: /usr/bin/node /opt/PlanktoScope/lib/mediamtx.js


### PR DESCRIPTION
  ## Summary

  An error I found in testing this week. This is to fix the silent WebRTC failure that causes the dashboard preview iframe to spin forever after any reset or redeploy of
  \`/etc/mediamtx.yaml\`.
  
  ## Root cause

  \`os/mediamtx/mediamtx.yaml\` ships with placeholders in \`webrtcAdditionalHosts\`:

  \`\`\`yaml
  webrtcAdditionalHosts: [
      192.0.2.1,           # placeholder IP
      raspberrypi,         # placeholder hostname
      raspberrypi.local,   # placeholder hostname.local
      ...
  ]
  \`\`\`

  These are runtime-substituted by \`lib/mediamtx.js\`, called from the backend's \`network.js\` whenever its
  \`wired_controller\` observable emits. If the substitution hasn't happened (boot race, image redeploy, manual revert,
  config reset), MediaMTX advertises \`raspberrypi\` in WebRTC ICE candidates. Browsers try to resolve it, get \`no such
  host\`, and **silently fail peer-connection negotiation** — the dashboard preview just shows an infinite spinner with no
  visible error.

  The failure surfaces in mediamtx logs as:
  \`\`\`
  INF [WebRTC] [session ...] closed: lookup raspberrypi on <dns>:53: no such host
  \`\`\`    

  …but HTTP-level probes (curl on \`/cam/\`, \`/cam/index.m3u8\`) all return normal content, so the bug is invisible to 
  anything but a real browser doing WebRTC ICE.
  
  ## Fix

  Run \`lib/mediamtx.js\` as \`ExecStartPre\` so the YAML is always rewritten with the device's real hostname/IP before 
  MediaMTX loads it. Also bump the unit's network dependency from \`network.target\` to \`network-online.target\` so 
  \`getWiredAddress()\` can read the IP when the script runs.                                        

  No change needed to \`lib/mediamtx.js\` — its trailing IIFE already gates on \`import.meta.main\`, which Node 24 (the 
  version we ship) supports natively. Invoking the file directly runs the substitution and exits.
